### PR TITLE
Port handling of TwoValuesToCellNodeModel improved

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeModel.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeModel.java
@@ -135,6 +135,9 @@ public abstract class TwoValuesToCellNodeModel<VIN1 extends DataValue, VIN2 exte
     }
 
     private static PortType[] createPortTypes(final PortType[] additionalPorts) {
+        if( additionalPorts == null ){
+            return new PortType[]{ BufferedDataTable.TYPE };
+        }
         final PortType[] inPTypes = new PortType[additionalPorts.length + 1];
         inPTypes[0] = BufferedDataTable.TYPE;
         for (int i = 0; i < additionalPorts.length; i++) {


### PR DESCRIPTION
Now its possible to only add outports (not only inports)
