### PR TITLE
Fix for Waehlby Cellclump Splitter

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
@@ -278,7 +278,6 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         { /*scope for object pair finding */
             ArrayList<int[]> points = new ArrayList<int[]>();
 
-            int squaredDistanceThreshold = m_seedDistanceThreshold * m_seedDistanceThreshold;
             boolean found = false;
 
             NeighborhoodsAccessible<LabelingType<String>> raNeighWatershed =
@@ -303,7 +302,7 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
                     final double diffY =
                             (iCenter[1] + iPoly.getBounds2D().getY()) - (jCenter[1] + jPoly.getBounds2D().getY());
 
-                    if ((diffX * diffX + diffY * diffY) < squaredDistanceThreshold) {
+                    if ((diffX * diffX + diffY * diffY) < m_seedDistanceThreshold) {
                         found = false; //reset flag
 
                         // find two points close to each other


### PR DESCRIPTION
Duplicate of #123 by @tibuch, which was closed before I was able to clean out the branch. Since closed, github wasn't able to adjust the existing pull request to the force push I had to do to get rid of the irrelevant commits.

@tibuch wrote:
> Changed seedDistance from squared to non squared.

Very small fix for the dialog option "Distance Threshold".