### PR TITLE
V210 node descriptions

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/node/AbstractValueToCellNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/AbstractValueToCellNodeFactory.java
@@ -64,9 +64,16 @@ import org.knime.node.v210.KnimeNodeDocument;
 import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
+ * {@link AbstractValueToCellNodeFactory} is a abstract implementation of {@link DynamicNodeFactory} for
+ * {@link BufferedDataTableHolder} {@link NodeModel}, which have a {@link NodeDialogPane} and adds a
+ * {@link TableCellViewNodeView} to it.
  *
  * @param <DIALOG> dialog pane type
  * @param <MODEL> node model type
+ *
+ * @see TwoValuesToCellNodeFactory
+ * @see ValueToCellsNodeFactory
+ * @see GenericValueToCellNodeFactory
  *
  * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
  */
@@ -74,12 +81,13 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
         extends DynamicNodeFactory<MODEL> {
 
     /**
-     * Check if the inheriting class is using deprecated node descriptions.
+     * Check if the subclass is using deprecated node descriptions.
      *
      * @return true if the derived class overrides
      *         {@link #addNodeDescriptionContent(org.knime.node2012.KnimeNodeDocument.KnimeNode)}.
-     *
+     * @deprecated Remove when support for deprecated node descriptions is dropped.
      */
+    @Deprecated
     private boolean usingDeprecatedDoc() {
         try {
             // get the deprecated addNodeDescriptionContent method
@@ -92,8 +100,7 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
                 return true;
             }
 
-            method = getClass().getMethod("createNodeDescription",
-                                                      org.knime.node2012.KnimeNodeDocument.class);
+            method = getClass().getMethod("createNodeDescription", org.knime.node2012.KnimeNodeDocument.class);
 
             // return whether subclass overrides deprecated createNodeDescription(...)
             return method.getDeclaringClass() != AbstractValueToCellNodeFactory.class;
@@ -109,6 +116,7 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
     @Override
     protected final NodeDescription createNodeDescription() {
         if (usingDeprecatedDoc()) {
+            // TODO: remove when support for deprecated node descriptions is dropped.
             return createNodeDescriptionDeprecated();
         }
 
@@ -177,6 +185,7 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
      * {@link GenericValueToCellNodeFactory#createNodeDescription(KnimeNodeDocument)}.
      *
      * @param node
+     * @see #createNodeDescription(KnimeNodeDocument)
      */
     protected void addNodeDescriptionContent(final KnimeNode node) {
         // Nothing to do here
@@ -188,7 +197,10 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
      * {@link GenericValueToCellNodeFactory#createNodeDescription(KnimeNodeDocument)}.
      *
      * @param node
-     * @deprecated Consider using {@link org.knime.node.v210.KnimeNodeDocument.KnimeNode} instead.
+     * @see #createNodeDescription(org.knime.node2012.KnimeNodeDocument)
+     * @deprecated Consider using Consider using {@link org.knime.node.v210.KnimeNodeDocument.KnimeNode} and override
+     *             {@link #createNodeDescription(org.knime.node.v210.KnimeNodeDocument)} and
+     *             {@link #addNodeDescriptionContent(org.knime.node.v210.KnimeNodeDocument.KnimeNode)} instead.
      */
     @Deprecated
     protected void addNodeDescriptionContent(final org.knime.node2012.KnimeNodeDocument.KnimeNode node) {
@@ -200,6 +212,7 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
      * named after the derived class will not be used.
      *
      * @param doc
+     * @see #addNodeDescriptionContent(KnimeNode)
      */
     protected void createNodeDescription(final KnimeNodeDocument doc) {
         // May be overwritten
@@ -210,7 +223,11 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
      * named after the derived class will not be used.
      *
      * @param doc
-     * @deprecated Consider using {@link org.knime.node.v210.KnimeNodeDocument} instead.
+     * @see #addNodeDescriptionContent(org.knime.node2012.KnimeNodeDocument.KnimeNode)
+     * @deprecated Consider using {@link org.knime.node.v210.KnimeNodeDocument} and override
+     *             {@link #createNodeDescription(org.knime.node.v210.KnimeNodeDocument)} and
+     *             {@link #addNodeDescriptionContent(org.knime.node.v210.KnimeNodeDocument.KnimeNode)} instead.
+     *
      */
     @Deprecated
     protected void createNodeDescription(final org.knime.node2012.KnimeNodeDocument doc) {
@@ -245,14 +262,17 @@ public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPa
      * {@inheritDoc}
      */
     @Override
-    protected final DIALOG createNodeDialogPane() {
+    protected DIALOG createNodeDialogPane() {
         return createNodeDialog();
     }
 
     /**
-     *
      * @return the new dialog
+     * @deprecated Override {@link #createNodeDialogPane()} instead (renaming should do the job).
      */
+    @Deprecated
+    /* TODO: Remove with next major API breaking release. #createNodeDialogPane()
+     * is just fine and has better naming (since returns a NodeDialogPane) */
     protected abstract DIALOG createNodeDialog();
 
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/node/AbstractValueToCellNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/AbstractValueToCellNodeFactory.java
@@ -1,0 +1,163 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright (C) 2003 - 2015
+ *  University of Konstanz, Germany and
+ *  KNIME GmbH, Konstanz, Germany
+ *  Website: http://www.knime.org; Email: contact@knime.org
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME GMBH herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * Created on Jun 3, 2015 by squareys
+ */
+package org.knime.knip.base.node;
+
+import org.knime.core.node.BufferedDataTableHolder;
+import org.knime.core.node.DynamicNodeFactory;
+import org.knime.core.node.NodeDescription;
+import org.knime.core.node.NodeDescription210Proxy;
+import org.knime.core.node.NodeDialogPane;
+import org.knime.core.node.NodeModel;
+import org.knime.core.node.NodeView;
+import org.knime.knip.base.nodes.view.TableCellViewNodeView;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+
+/**
+ *
+ * @param <DIALOG> dialog pane type
+ * @param <MODEL> node model type
+ *
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
+ */
+public abstract class AbstractValueToCellNodeFactory<DIALOG extends NodeDialogPane, MODEL extends NodeModel & BufferedDataTableHolder> extends DynamicNodeFactory<MODEL>{
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final NodeDescription createNodeDescription() {
+        final KnimeNodeDocument doc = KnimeNodeDocument.Factory.newInstance();
+        createNodeDescription(doc);
+
+        KnimeNode node = doc.getKnimeNode();
+        if (node == null) {
+            XMLNodeUtils.addXMLNodeDescriptionTo(doc, this.getClass());
+            node = doc.getKnimeNode();
+        }
+
+        // Load if possible
+        if (node != null) {
+
+            // add description of "this" dialog
+            ValueToCellNodeDialog.addTabsDescriptionTo(node.getFullDescription());
+            TableCellViewNodeView.addViewDescriptionTo(node.addNewViews());
+
+            if (node.getPorts() == null) {
+                ValueToCellNodeDialog.addPortsDescriptionTo(node);
+            }
+
+            // Add user stuff
+            addNodeDescriptionContent(node);
+        }
+
+        return new NodeDescription210Proxy(doc);
+    }
+
+    /**
+     * Overwrite this method to add additional details programmatically to the already existing node description
+     * (created either from an xml file or in
+     * {@link GenericValueToCellNodeFactory#createNodeDescription(KnimeNodeDocument)}.
+     *
+     * @param node
+     */
+    protected void addNodeDescriptionContent(final KnimeNode node) {
+        // Nothing to do here
+    }
+
+    /**
+     * Overwrite this method if you want to create the node description programmatically. A description in the xml file
+     * named after the derived class will not be used.
+     *
+     * @param doc
+     */
+    protected void createNodeDescription(final KnimeNodeDocument doc) {
+        // May be overwritten
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected int getNrNodeViews() {
+        return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NodeView<MODEL> createNodeView(final int viewIndex, final MODEL nodeModel) {
+        return new TableCellViewNodeView<MODEL>(nodeModel);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final boolean hasDialog() {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final DIALOG createNodeDialogPane() {
+        return createNodeDialog();
+    }
+
+    /**
+     *
+     * @return the new dialog
+     */
+    protected abstract DIALOG createNodeDialog();
+
+}

--- a/org.knime.knip.base/src/org/knime/knip/base/node/GenericValueToCellNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/GenericValueToCellNodeFactory.java
@@ -50,12 +50,7 @@ package org.knime.knip.base.node;
 
 import org.knime.core.data.DataCell;
 import org.knime.core.data.DataValue;
-import org.knime.core.node.DynamicNodeFactory;
 import org.knime.core.node.NodeSetFactory;
-import org.knime.core.node.NodeView;
-import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
 
 /**
  * Node factory mapping one data value to a data cell. Please note that if this factory is used, the node has to be
@@ -70,96 +65,6 @@ import org.knime.node2012.KnimeNodeDocument.KnimeNode;
  * @param <M>
  */
 public abstract class GenericValueToCellNodeFactory<VIN extends DataValue, M extends ValueToCellNodeModel<VIN, ? extends DataCell>>
-        extends DynamicNodeFactory<M> {
-
-    /**
-     * {@inheritDoc}
-     */
-    @SuppressWarnings("deprecation")
-    @Override
-    protected final void addNodeDescription(final KnimeNodeDocument doc) {
-        createNodeDescription(doc);
-
-        KnimeNode node = doc.getKnimeNode();
-        if (node == null) {
-            XMLNodeUtils.addXMLNodeDescriptionTo(doc, this.getClass());
-            node = doc.getKnimeNode();
-        }
-
-        // Load if possible
-        if (node != null) {
-
-            // add description of "this" dialog
-            ValueToCellNodeDialog.addTabsDescriptionTo(node.getFullDescription());
-            TableCellViewNodeView.addViewDescriptionTo(node.addNewViews());
-
-            if (node.getPorts() == null) {
-                ValueToCellNodeDialog.addPortsDescriptionTo(node);
-            }
-
-            // Add user stuff
-            addNodeDescriptionContent(node);
-        }
-    }
-
-    /**
-     * Overwrite this method to add additional details programmatically to the already existing node description
-     * (created either from an xml file or in
-     * {@link GenericValueToCellNodeFactory#createNodeDescription(KnimeNodeDocument)}.
-     *
-     * @param node
-     */
-    protected void addNodeDescriptionContent(final KnimeNode node) {
-        // Nothing to do here
-    }
-
-    /**
-     * Overwrite this method if you want to create the node description programmatically. A description in the xml file
-     * named after the derived class will not be used.
-     *
-     * @param doc
-     */
-    protected void createNodeDescription(final KnimeNodeDocument doc) {
-        // May be overwritten
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected int getNrNodeViews() {
-        return 1;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public NodeView<M> createNodeView(final int viewIndex, final M nodeModel) {
-        return new TableCellViewNodeView<M>(nodeModel);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected final boolean hasDialog() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     */
-    @Override
-    protected final ValueToCellNodeDialog<VIN> createNodeDialogPane() {
-        return createNodeDialog();
-    }
-
-    /**
-     *
-     * @return the new dialog
-     */
-    protected abstract ValueToCellNodeDialog<VIN> createNodeDialog();
+        extends AbstractValueToCellNodeFactory<ValueToCellNodeDialog<VIN>, M> {
 
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/node/GenericValueToCellNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/GenericValueToCellNodeFactory.java
@@ -60,9 +60,10 @@ import org.knime.core.node.NodeSetFactory;
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
  *
- * @param <VIN>
- * @param <M>
+ * @param <VIN> Input {@link DataValue}.
+ * @param <M> Subtype of {@link ValueToCellNodeModel} which is created by this factory.
  */
 public abstract class GenericValueToCellNodeFactory<VIN extends DataValue, M extends ValueToCellNodeModel<VIN, ? extends DataCell>>
         extends AbstractValueToCellNodeFactory<ValueToCellNodeDialog<VIN>, M> {

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ImgPlusToImgPlusNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ImgPlusToImgPlusNodeFactory.java
@@ -53,7 +53,7 @@ import net.imglib2.type.numeric.RealType;
 import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.dialog.DescriptionHelper;
 import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link ImgPlusToImgPlusNodeFactory}

--- a/org.knime.knip.base/src/org/knime/knip/base/node/IterableIntervalsNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/IterableIntervalsNodeFactory.java
@@ -53,10 +53,10 @@ import net.imglib2.type.numeric.RealType;
 
 import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
-import org.knime.node2012.UlDocument.Ul;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
+import org.knime.node.v210.UlDocument.Ul;
 
 /**
  * NodeFactory for {@link IterableIntervalsNodeModel}

--- a/org.knime.knip.base/src/org/knime/knip/base/node/IterableIntervalsNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/IterableIntervalsNodeFactory.java
@@ -115,10 +115,10 @@ public abstract class IterableIntervalsNodeFactory<T extends RealType<T>, V exte
                 .newCursor()
                 .setTextValue("The FillingMode determines how all values, which lie outside your defined region of interest, will be set. This option is only needed if you choose a labeling column, such that the node operates on ROIs instead of the entire image. There are currently four FillingModes:");
         Ul list = opt.addNewUl();
-        list.addLi("Value of Source: In this mode, pixels outside of the ROIs remain unchanged. ");
-        list.addLi("Minimum of Result Type: Here, values outside of the ROI are set to the smallest legal value of the output image type. ");
-        list.addLi("Maximum of Result Type: All values outside of the ROI are set to the largest posible value of the output image type. ");
-        list.addLi("No Filling: No action is taken after initializing the target image, thus all pixels outside the ROIs remain zero. ");
+        list.addNewLi().addNewTt().setStringValue("Value of Source: In this mode, pixels outside of the ROIs remain unchanged. ");
+        list.addNewLi().addNewTt().setStringValue("Minimum of Result Type: Here, values outside of the ROI are set to the smallest legal value of the output image type. ");
+        list.addNewLi().addNewTt().setStringValue("Maximum of Result Type: All values outside of the ROI are set to the largest posible value of the output image type. ");
+        list.addNewLi().addNewTt().setStringValue("No Filling: No action is taken after initializing the target image, thus all pixels outside the ROIs remain zero. ");
 
     }
 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/LabelingToLabelingNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/LabelingToLabelingNodeFactory.java
@@ -50,7 +50,7 @@ package org.knime.knip.base.node;
 
 import org.knime.knip.base.data.labeling.LabelingValue;
 import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link LabelingToLabelingNodeDialog} for corresponding {@link LabelingToLabelingNodeModel}

--- a/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeDialog.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeDialog.java
@@ -50,6 +50,7 @@ package org.knime.knip.base.node;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -62,13 +63,13 @@ import org.knime.core.node.defaultnodesettings.DialogComponentColumnNameSelectio
 import org.knime.core.node.defaultnodesettings.DialogComponentString;
 import org.knime.core.node.defaultnodesettings.DialogComponentStringSelection;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.InPortDocument.InPort;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.OutPortDocument.OutPort;
-import org.knime.node2012.PortsDocument.Ports;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.InPortDocument.InPort;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.OutPortDocument.OutPort;
+import org.knime.node.v210.PortsDocument.Ports;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * TODO: Standard description
@@ -126,11 +127,11 @@ public abstract class TwoValuesToCellNodeDialog<VIN1 extends DataValue, VIN2 ext
         final InPort inPort = ports.addNewInPort();
         inPort.newCursor().setTextValue("Images");
         inPort.setName("Images");
-        inPort.setIndex(0);
+        inPort.setIndex(new BigInteger("0"));
         inPort.newCursor().setTextValue("Images");
         final OutPort outPort = ports.addNewOutPort();
         outPort.setName("Processed Images");
-        outPort.setIndex(0);
+        outPort.setIndex(new BigInteger("0"));
         outPort.newCursor().setTextValue("Processed Images");
     }
 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeFactory.java
@@ -60,6 +60,10 @@ import org.knime.core.node.NodeSetFactory;
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
+ *
+ * @see TwoValuesToCellNodeModel
+ * @see TwoValuesToCellNodeDialog
  *
  * @param <VIN1>
  * @param <VIN2>

--- a/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/TwoValuesToCellNodeFactory.java
@@ -50,12 +50,7 @@ package org.knime.knip.base.node;
 
 import org.knime.core.data.DataCell;
 import org.knime.core.data.DataValue;
-import org.knime.core.node.DynamicNodeFactory;
 import org.knime.core.node.NodeSetFactory;
-import org.knime.core.node.NodeView;
-import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
 
 /**
  * Node factory mapping two data values to a data cell. Please note that if this factory is used, the node has to be
@@ -69,102 +64,7 @@ import org.knime.node2012.KnimeNodeDocument.KnimeNode;
  * @param <VIN1>
  * @param <VIN2>
  */
-public abstract class TwoValuesToCellNodeFactory<VIN1 extends DataValue, VIN2 extends DataValue> extends
-        DynamicNodeFactory<TwoValuesToCellNodeModel<VIN1, VIN2, ? extends DataCell>> {
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated
-     */
-    @Deprecated
-    @Override
-    protected final void addNodeDescription(final KnimeNodeDocument doc) {
-        createNodeDescription(doc);
-
-        KnimeNode node = doc.getKnimeNode();
-        if (node == null) {
-            XMLNodeUtils.addXMLNodeDescriptionTo(doc, this.getClass());
-            node = doc.getKnimeNode();
-        }
-
-        // Load if possible
-        if (node != null) {
-
-            // add description of this dialog
-            TwoValuesToCellNodeDialog.addTabsDescriptionTo(node.getFullDescription());
-            TableCellViewNodeView.addViewDescriptionTo(node.addNewViews());
-
-            if (node.getPorts() == null) {
-                //add default port description
-                TwoValuesToCellNodeDialog.addPortsDescriptionTo(node);
-            }
-
-            // Add user stuff
-            addNodeDescriptionContent(node);
-        }
-    }
-
-    /**
-     * Overwrite this method to add additional details programmatically to the already existing node description
-     * (created either from an xml file or in
-     * {@link TwoValuesToCellNodeFactory#createNodeDescription(KnimeNodeDocument)}.
-     *
-     * @param node
-     */
-    protected void addNodeDescriptionContent(final KnimeNode node) {
-        // Nothing to do here
-    }
-
-    /**
-     * Overwrite this method if you want to create the node description programmatically. A description in the xml file
-     * named after the derived class will not be used.
-     *
-     * @param doc
-     */
-    protected void createNodeDescription(final KnimeNodeDocument doc) {
-        // May be overwritten
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected int getNrNodeViews() {
-        return 1;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public
-            NodeView<TwoValuesToCellNodeModel<VIN1, VIN2, ? extends DataCell>>
-            createNodeView(final int viewIndex, final TwoValuesToCellNodeModel<VIN1, VIN2, ? extends DataCell> nodeModel) {
-        return new TableCellViewNodeView<TwoValuesToCellNodeModel<VIN1, VIN2, ? extends DataCell>>(nodeModel);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected final boolean hasDialog() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     */
-    @Override
-    protected TwoValuesToCellNodeDialog<VIN1, VIN2> createNodeDialogPane() {
-        return createNodeDialog();
-    }
-
-    /**
-     *
-     * @return the new dialog
-     */
-    protected abstract TwoValuesToCellNodeDialog<VIN1, VIN2> createNodeDialog();
-
+public abstract class TwoValuesToCellNodeFactory<VIN1 extends DataValue, VIN2 extends DataValue>
+        extends
+        AbstractValueToCellNodeFactory<TwoValuesToCellNodeDialog<VIN1, VIN2>, TwoValuesToCellNodeModel<VIN1, VIN2, ? extends DataCell>> {
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellNodeDialog.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellNodeDialog.java
@@ -78,8 +78,9 @@ import org.knime.node.v210.TabDocument.Tab;
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
  *
- * @param <VIN>
+ * @param <VIN> Input {@link DataValue}.
  */
 public abstract class ValueToCellNodeDialog<VIN extends DataValue> extends LazyNodeDialogPane {
 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellNodeDialog.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellNodeDialog.java
@@ -102,6 +102,26 @@ public abstract class ValueToCellNodeDialog<VIN extends DataValue> extends LazyN
     }
 
     /**
+     * Adds the port description to the node description.
+     *
+     * @param node
+     * @deprecated Consider using {@link org.knime.node.v210.KnimeNodeDocument.KnimeNode} instead.
+     */
+    @Deprecated
+    static void addPortsDescriptionTo(final org.knime.node2012.KnimeNodeDocument.KnimeNode node) {
+        final org.knime.node2012.PortsDocument.Ports ports = node.addNewPorts();
+        final org.knime.node2012.InPortDocument.InPort inPort = ports.addNewInPort();
+        inPort.newCursor().setTextValue("Images");
+        inPort.setName("Images");
+        inPort.setIndex(0);
+        inPort.newCursor().setTextValue("Images");
+        final org.knime.node2012.OutPortDocument.OutPort outPort = ports.addNewOutPort();
+        outPort.setName("Processed Images");
+        outPort.setIndex(0);
+        outPort.newCursor().setTextValue("Processed Images");
+    }
+
+    /**
      * Adds the description of the column selection tab to the node description.
      *
      * @param desc
@@ -110,6 +130,30 @@ public abstract class ValueToCellNodeDialog<VIN extends DataValue> extends LazyN
         final Tab tab = desc.addNewTab();
         tab.setName("Column Selection");
         Option opt = tab.addNewOption();
+        opt.setName("Column Creation Mode");
+        opt.addNewP()
+                .newCursor()
+                .setTextValue("Mode how to handle the selected column. The processed column can be added to a new table, appended to the end of the table, or the old column can be replaced by the new result");
+        opt = tab.addNewOption();
+        opt.setName("Column Suffix");
+        opt.newCursor()
+                .setTextValue("A suffix appended to the column name. If \"Append\" is not selected, it can be left empty.");
+        opt = tab.addNewOption();
+        opt.setName("Column Selection");
+        opt.newCursor().setTextValue("Selection of the columns to be processed.");
+    }
+
+    /**
+     * Adds the description of the column selection tab to the node description.
+     *
+     * @param desc
+     * @deprecated Consider using {@link org.knime.node.v210.FullDescriptionDocument.FullDescription} instead.
+     */
+    @Deprecated
+    static void addTabsDescriptionTo(final org.knime.node2012.FullDescriptionDocument.FullDescription desc) {
+        final org.knime.node2012.TabDocument.Tab tab = desc.addNewTab();
+        tab.setName("Column Selection");
+        org.knime.node2012.OptionDocument.Option opt = tab.addNewOption();
         opt.setName("Column Creation Mode");
         opt.addNewP()
                 .newCursor()

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellNodeDialog.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellNodeDialog.java
@@ -50,6 +50,7 @@ package org.knime.knip.base.node;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -62,13 +63,13 @@ import org.knime.core.node.defaultnodesettings.DialogComponentColumnFilter;
 import org.knime.core.node.defaultnodesettings.DialogComponentString;
 import org.knime.core.node.defaultnodesettings.DialogComponentStringSelection;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.InPortDocument.InPort;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.OutPortDocument.OutPort;
-import org.knime.node2012.PortsDocument.Ports;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.InPortDocument.InPort;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.OutPortDocument.OutPort;
+import org.knime.node.v210.PortsDocument.Ports;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * Dialog corresponding to the {@link ValueToCellNodeModel} which already contains dialog components, but others can
@@ -92,11 +93,11 @@ public abstract class ValueToCellNodeDialog<VIN extends DataValue> extends LazyN
         final InPort inPort = ports.addNewInPort();
         inPort.newCursor().setTextValue("Images");
         inPort.setName("Images");
-        inPort.setIndex(0);
+        inPort.setIndex(new BigInteger("0"));
         inPort.newCursor().setTextValue("Images");
         final OutPort outPort = ports.addNewOutPort();
         outPort.setName("Processed Images");
-        outPort.setIndex(0);
+        outPort.setIndex(new BigInteger("0"));
         outPort.newCursor().setTextValue("Processed Images");
     }
 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellsNodeDialog.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellsNodeDialog.java
@@ -56,9 +56,9 @@ import org.knime.core.node.defaultnodesettings.DialogComponent;
 import org.knime.core.node.defaultnodesettings.DialogComponentColumnNameSelection;
 import org.knime.core.node.defaultnodesettings.DialogComponentStringSelection;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * Dialog corresponding to the {@link ValueToCellsNodeModel} which already contains dialog components, but others can

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellsNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellsNodeFactory.java
@@ -49,12 +49,7 @@
 package org.knime.knip.base.node;
 
 import org.knime.core.data.DataValue;
-import org.knime.core.node.DynamicNodeFactory;
 import org.knime.core.node.NodeSetFactory;
-import org.knime.core.node.NodeView;
-import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
 
 /**
  * Node factory mapping a data values to multiple data cell. Please note that if this factory is used, the node has to
@@ -68,99 +63,6 @@ import org.knime.node2012.KnimeNodeDocument.KnimeNode;
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
  */
 public abstract class ValueToCellsNodeFactory<VIN extends DataValue> extends
-        DynamicNodeFactory<ValueToCellsNodeModel<VIN>> {
-
-    /**
-     * {@inheritDoc}
-     * @deprecated
-     */
-    @Deprecated
-    @Override
-    protected final void addNodeDescription(final KnimeNodeDocument doc) {
-        createNodeDescription(doc);
-
-        KnimeNode node = doc.getKnimeNode();
-        if (node == null) {
-            XMLNodeUtils.addXMLNodeDescriptionTo(doc, this.getClass());
-            node = doc.getKnimeNode();
-        }
-
-        // Load if possible
-        if (node != null) {
-
-            // add description of this dialog
-            ValueToCellsNodeDialog.addTabsDescriptionTo(doc.getKnimeNode().getFullDescription());
-            TableCellViewNodeView.addViewDescriptionTo(node.addNewViews());
-
-            if (node.getPorts() == null) {
-                //add default port description
-                //TODO!
-            }
-
-            // Add user stuff
-            addNodeDescriptionContent(node);
-        }
-    }
-
-    /**
-     * Overwrite this method to add additional details programmatically to the already existing node description
-     * (created either from an xml file or in {@link ValueToCellsNodeFactory#createNodeDescription(KnimeNodeDocument)}.
-     *
-     * @param node
-     */
-    protected void addNodeDescriptionContent(final KnimeNode node) {
-        // Nothing to do here
-    }
-
-    /**
-     * Overwrite this method if you want to create the node description programmatically. A description in the xml file
-     * named after the derived class will not be used.
-     *
-     * @param doc
-     */
-    protected void createNodeDescription(final KnimeNodeDocument doc) {
-        // May be overwritten
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected int getNrNodeViews() {
-        return 1;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public NodeView<ValueToCellsNodeModel<VIN>> createNodeView(final int viewIndex,
-                                                               final ValueToCellsNodeModel<VIN> nodeModel) {
-        return new TableCellViewNodeView<ValueToCellsNodeModel<VIN>>(nodeModel);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected final boolean hasDialog() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     */
-    @Override
-    protected ValueToCellsNodeDialog<VIN> createNodeDialogPane() {
-        return createNodeDialog();
-    }
-
-    /**
-     * Create {@link ValueToCellNodeDialog}
-     *
-     * @return the new dialog
-     */
-    protected abstract ValueToCellsNodeDialog<VIN> createNodeDialog();
+        AbstractValueToCellNodeFactory<ValueToCellsNodeDialog<VIN>, ValueToCellsNodeModel<VIN>> {
 
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellsNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/ValueToCellsNodeFactory.java
@@ -57,10 +57,14 @@ import org.knime.core.node.NodeSetFactory;
  * NOT work so far.
  *
  *
- * @param <VIN>
+ * @param <VIN> Input {@link DataValue}.
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
+ *
+ * @see ValueToCellsNodeModel
+ * @see ValueToCellsNodeDialog
  */
 public abstract class ValueToCellsNodeFactory<VIN extends DataValue> extends
         AbstractValueToCellNodeFactory<ValueToCellsNodeDialog<VIN>, ValueToCellsNodeModel<VIN>> {

--- a/org.knime.knip.base/src/org/knime/knip/base/node/XMLNodeUtils.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/XMLNodeUtils.java
@@ -57,8 +57,8 @@ import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
 import org.knime.core.node.NodeFactory;
 import org.knime.core.node.NodeLogger;
-import org.knime.node.v28.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * Helper class essentially to parse and add the xml-file content to XMLBeans objects representing the node description
@@ -72,7 +72,7 @@ public class XMLNodeUtils {
 
     private static final NodeLogger LOGGER = NodeLogger.getLogger(XMLNodeUtils.class);
 
-    private static final String NAMESPACE = "http://knime.org/node2012";
+    private static final String NAMESPACE = "http://knime.org/node/v2.10";
 
     /**
      * Adds the xml content of the file *NodeFactory.xml in the same package to the xml bean (KnimeNodeDocument).

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DescriptionHelper.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DescriptionHelper.java
@@ -50,7 +50,7 @@ package org.knime.knip.base.node.dialog;
 
 import java.util.List;
 
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentColumnCreationSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentColumnCreationSelection.java
@@ -50,7 +50,7 @@ package org.knime.knip.base.node.dialog;
 
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.knip.base.node.ValueToCellNodeModel;
-import org.knime.node2012.OptionDocument.Option;
+import org.knime.node.v210.OptionDocument.Option;
 
 /**
  * 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentColumnSuffix.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentColumnSuffix.java
@@ -49,7 +49,7 @@
 package org.knime.knip.base.node.dialog;
 
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
-import org.knime.node2012.OptionDocument.Option;
+import org.knime.node.v210.OptionDocument.Option;
 
 /**
  * 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentDimSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentDimSelection.java
@@ -73,7 +73,7 @@ import org.knime.core.node.defaultnodesettings.DialogComponent;
 import org.knime.core.node.port.PortObjectSpec;
 import org.knime.knip.base.KNIMEKNIPPlugin;
 import org.knime.knip.base.node.nodesettings.SettingsModelDimSelection;
-import org.knime.node2012.OptionDocument.Option;
+import org.knime.node.v210.OptionDocument.Option;
 
 /**
  * Dialog component to select image axis.

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentDimSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentDimSelection.java
@@ -323,4 +323,23 @@ public class DialogComponentDimSelection extends DialogComponent implements Item
                                       + "Example 2 with three dimensional Image (X,Y,Time): The algorithm can be applied in two, three or even more dimensions. Select the dimensions to define your plane/cube/hypercube on which the algorithm will be applied.");
 
     }
+
+    /**
+     * @param opt Option pane to add dimension selection description.
+     * @deprecated Consider using {@link org.knime.node.v210.OptionDocument.Option}
+     */
+    @Deprecated
+    public static void createNodeDescription(final org.knime.node2012.OptionDocument.Option opt) {
+        opt.setName("Dimension Selection");
+        opt.addNewP()
+                .newCursor()
+                .setTextValue("This component allows the selection of dimensions of interest."
+                                      + System.getProperty("line.separator")
+                                      + "If an algorithm cannot, as it only supports fewer dimensions than the number of dimensions of the image, or shouldnot, as one wants to run the algorithm only on subsets of the image, be applied on the complete image, the dimension selection can be used to define the plane/cube/hypercube on which the algorithm is applied."
+                                      + System.getProperty("line.separator")
+                                      + "Example 1 with three dimensional Image (X,Y,Time): An algorithm cannot be applied to the complete image, as it only supports two dimensional images. If you select e.g. X,Y then the algorithm will be applied to all X,Y planes individually."
+                                      + System.getProperty("line.separator")
+                                      + "Example 2 with three dimensional Image (X,Y,Time): The algorithm can be applied in two, three or even more dimensions. Select the dimensions to define your plane/cube/hypercube on which the algorithm will be applied.");
+
+    }
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentFactorySelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentFactorySelection.java
@@ -51,8 +51,8 @@ package org.knime.knip.base.node.dialog;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.knip.core.types.ImgFactoryTypes;
 import org.knime.knip.core.util.EnumUtils;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.PDocument.P;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.PDocument.P;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentOutOfBoundsSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentOutOfBoundsSelection.java
@@ -51,9 +51,9 @@ package org.knime.knip.base.node.dialog;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
 import org.knime.knip.core.util.EnumUtils;
-import org.knime.node2012.ADocument.A;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.PDocument.P;
+import org.knime.node.v210.ADocument.A;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.PDocument.P;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentPixelType.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentPixelType.java
@@ -51,8 +51,8 @@ package org.knime.knip.base.node.dialog;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.knip.core.types.NativeTypes;
 import org.knime.knip.core.util.EnumUtils;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.PDocument.P;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.PDocument.P;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentRadiusSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentRadiusSelection.java
@@ -49,8 +49,8 @@
 package org.knime.knip.base.node.dialog;
 
 import org.knime.core.node.defaultnodesettings.SettingsModel;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.PDocument.P;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.PDocument.P;
 
 /**
  * 

--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentSpanSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentSpanSelection.java
@@ -49,11 +49,11 @@
 package org.knime.knip.base.node.dialog;
 
 import org.knime.core.node.defaultnodesettings.SettingsModel;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.PDocument.P;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.PDocument.P;
 
 /**
- * 
+ *
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/AverageFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/AverageFilterNodeFactory.java
@@ -61,9 +61,9 @@ import net.imglib2.type.numeric.real.DoubleType;
 
 import org.knime.knip.core.ops.iterable.SlidingMeanIntegralImgBinaryOp;
 import org.knime.knip.core.util.ImgPlusFactory;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/GaussNativeTypeNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/GaussNativeTypeNodeFactory.java
@@ -71,8 +71,8 @@ import org.knime.knip.core.ops.filters.GaussNativeTypeOp;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
 import org.knime.knip.core.types.OutOfBoundsStrategyFactory;
 import org.knime.knip.core.util.ImgPlusFactory;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * NodeModel to wrap {@link Gauss3} Algorithm

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/SlidingWindowOperationNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/SlidingWindowOperationNodeFactory.java
@@ -59,10 +59,10 @@ import org.knime.knip.base.node.dialog.DialogComponentOutOfBoundsSelection;
 import org.knime.knip.base.node.dialog.DialogComponentSpanSelection;
 import org.knime.knip.core.types.NeighborhoodType;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/SobelNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/SobelNodeFactory.java
@@ -86,7 +86,7 @@ import org.knime.knip.core.algorithm.convolvers.filter.linear.ConstantFilter;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
 import org.knime.knip.core.types.OutOfBoundsStrategyFactory;
 import org.knime.knip.core.util.ImgUtils;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/VarianceFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/VarianceFilterNodeFactory.java
@@ -55,9 +55,9 @@ import net.imglib2.ops.operation.iterable.unary.Variance;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.numeric.RealType;
 
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link VarianceFilterNodeFactory} as {@link SlidingWindowOperationNodeFactory}

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/ConvolverNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/ConvolverNodeFactory.java
@@ -55,8 +55,8 @@ import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.ValueToCellNodeFactory;
 import org.knime.knip.base.node.dialog.DescriptionHelper;
 import org.knime.knip.base.node.dialog.DialogComponentOutOfBoundsSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/DirectAddDimConvolverExt.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/DirectAddDimConvolverExt.java
@@ -60,8 +60,8 @@ import net.imglib2.view.Views;
 import org.knime.knip.core.algorithm.convolvers.AdditionDimImgConvolver;
 import org.knime.knip.core.algorithm.convolvers.DirectConvolver;
 import org.knime.knip.core.types.OutOfBoundsStrategyFactory;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/DirectIterativeConvolverExt.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/DirectIterativeConvolverExt.java
@@ -68,8 +68,8 @@ import org.knime.knip.core.algorithm.convolvers.DirectIterativeConvolver;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
 import org.knime.knip.core.types.OutOfBoundsStrategyFactory;
 import org.knime.knip.core.util.ImgUtils;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/ImgLib2AddDimConvolverExt.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/ImgLib2AddDimConvolverExt.java
@@ -60,8 +60,8 @@ import net.imglib2.view.Views;
 import org.knime.knip.core.algorithm.convolvers.AdditionDimImgConvolver;
 import org.knime.knip.core.algorithm.convolvers.ImgLib2FourierConvolver;
 import org.knime.knip.core.types.OutOfBoundsStrategyFactory;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/ImgLib2IterativeConvolverExt.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/ImgLib2IterativeConvolverExt.java
@@ -68,8 +68,8 @@ import org.knime.knip.core.algorithm.convolvers.ImgLib2IterativeConvolver;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
 import org.knime.knip.core.types.OutOfBoundsStrategyFactory;
 import org.knime.knip.core.util.ImgUtils;
-import org.knime.node2012.OptionDocument.Option;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.OptionDocument.Option;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/MultiKernelImageConvolverExt.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/convolver/MultiKernelImageConvolverExt.java
@@ -59,7 +59,7 @@ import net.imglib2.type.numeric.RealType;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.knip.core.types.OutOfBoundsStrategyEnum;
-import org.knime.node2012.TabDocument.Tab;
+import org.knime.node.v210.TabDocument.Tab;
 
 /**
  * TODO Auto-generated

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/maxhomogenity/MaxHomogenityNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/maxhomogenity/MaxHomogenityNodeFactory.java
@@ -55,7 +55,7 @@ import org.knime.knip.base.node.ImgPlusToImgPlusNodeFactory;
 import org.knime.knip.base.node.ImgPlusToImgPlusNodeModel;
 import org.knime.knip.base.node.dialog.DescriptionHelper;
 import org.knime.knip.base.node.dialog.DialogComponentOutOfBoundsSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/BilateralFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/BilateralFilterNodeFactory.java
@@ -67,7 +67,7 @@ import org.knime.knip.base.node.dialog.DescriptionHelper;
 import org.knime.knip.base.node.dialog.DialogComponentSpanSelection;
 import org.knime.knip.core.ops.filters.BilateralFilter;
 import org.knime.knip.core.util.ImgPlusFactory;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link NodeModel} for {@link BilateralFilter}

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/MaxFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/MaxFilterNodeFactory.java
@@ -59,9 +59,9 @@ import org.knime.core.node.NodeModel;
 import org.knime.knip.base.nodes.filter.AbstractSlidingWindowOperationNodeModel;
 import org.knime.knip.base.nodes.filter.SlidingWindowOperationNodeDialog;
 import org.knime.knip.base.nodes.filter.SlidingWindowOperationNodeFactory;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link NodeModel} for implementation of Max Filter

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/MedianFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/MedianFilterNodeFactory.java
@@ -60,9 +60,9 @@ import org.knime.core.node.NodeModel;
 import org.knime.knip.base.nodes.filter.AbstractSlidingWindowOperationNodeModel;
 import org.knime.knip.base.nodes.filter.SlidingWindowOperationNodeDialog;
 import org.knime.knip.base.nodes.filter.SlidingWindowOperationNodeFactory;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link NodeModel} for naive implementation of a Median Filter

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/MinFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/MinFilterNodeFactory.java
@@ -59,9 +59,9 @@ import org.knime.core.node.NodeModel;
 import org.knime.knip.base.nodes.filter.AbstractSlidingWindowOperationNodeModel;
 import org.knime.knip.base.nodes.filter.SlidingWindowOperationNodeDialog;
 import org.knime.knip.base.nodes.filter.SlidingWindowOperationNodeFactory;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link NodeModel} for Minimum Filter

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/QuantileFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/nonlinear/QuantileFilterNodeFactory.java
@@ -78,7 +78,7 @@ import org.knime.knip.base.node.dialog.DescriptionHelper;
 import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
 import org.knime.knip.base.node.dialog.DialogComponentSpanSelection;
 import org.knime.knip.base.node.nodesettings.SettingsModelDimSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/sigma/SigmaFilterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/filter/sigma/SigmaFilterNodeFactory.java
@@ -55,7 +55,7 @@ import org.knime.knip.base.node.ImgPlusToImgPlusNodeFactory;
 import org.knime.knip.base.node.dialog.DescriptionHelper;
 import org.knime.knip.base.node.dialog.DialogComponentOutOfBoundsSelection;
 import org.knime.knip.core.ops.iterator.SigmaFilter;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  *

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/io/imggenerator/ImgGeneratorNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/io/imggenerator/ImgGeneratorNodeFactory.java
@@ -52,16 +52,18 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
 import org.knime.core.node.DynamicNodeFactory;
+import org.knime.core.node.NodeDescription;
+import org.knime.core.node.NodeDescription210Proxy;
 import org.knime.core.node.NodeDialogPane;
 import org.knime.core.node.NodeView;
 import org.knime.knip.base.node.XMLNodeUtils;
 import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * The Factory class for the Image Reader.
- * 
+ *
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
@@ -110,7 +112,9 @@ public class ImgGeneratorNodeFactory<T extends NativeType<T> & RealType<T>> exte
     }
 
     @Override
-    protected final void addNodeDescription(final KnimeNodeDocument doc) {
+    protected NodeDescription createNodeDescription() {
+        KnimeNodeDocument doc = KnimeNodeDocument.Factory.newInstance();
+
         KnimeNode node = doc.getKnimeNode();
         if (node == null) {
             XMLNodeUtils.addXMLNodeDescriptionTo(doc, this.getClass());
@@ -121,6 +125,9 @@ public class ImgGeneratorNodeFactory<T extends NativeType<T> & RealType<T>> exte
         if (node != null) {
             TableCellViewNodeView.addViewDescriptionTo(node.addNewViews());
         }
+
+        return new NodeDescription210Proxy(doc);
     }
+
 
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/io/kernel/ConvolutionKernelNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/io/kernel/ConvolutionKernelNodeFactory.java
@@ -54,6 +54,8 @@ import java.util.Map;
 import net.imglib2.type.numeric.RealType;
 
 import org.knime.core.node.DynamicNodeFactory;
+import org.knime.core.node.NodeDescription;
+import org.knime.core.node.NodeDescription210Proxy;
 import org.knime.core.node.NodeDialogPane;
 import org.knime.core.node.NodeView;
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
@@ -71,11 +73,11 @@ import org.knime.knip.base.nodes.io.kernel.filter.PrewittConfiguration;
 import org.knime.knip.base.nodes.io.kernel.filter.RobertsConfiguration;
 import org.knime.knip.base.nodes.io.kernel.filter.SobelConfiguration;
 import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument;
 
 /**
  * TODO Auto-generated
- * 
+ *
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
@@ -90,11 +92,16 @@ public class ConvolutionKernelNodeFactory<T extends RealType<T>> extends Dynamic
 
     /**
      * {@inheritDoc}
+     * @return
      */
     @Override
-    protected void addNodeDescription(final KnimeNodeDocument doc) {
+    protected NodeDescription createNodeDescription() {
+        KnimeNodeDocument doc = KnimeNodeDocument.Factory.newInstance();
+
         XMLNodeUtils.addXMLNodeDescriptionTo(doc, getClass());
         TableCellViewNodeView.addViewDescriptionTo(doc.getKnimeNode().addNewViews());
+
+        return new NodeDescription210Proxy(doc);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/io/kernel/StructuringElementNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/io/kernel/StructuringElementNodeFactory.java
@@ -54,6 +54,8 @@ import java.util.Map;
 import net.imglib2.type.numeric.RealType;
 
 import org.knime.core.node.DynamicNodeFactory;
+import org.knime.core.node.NodeDescription;
+import org.knime.core.node.NodeDescription210Proxy;
 import org.knime.core.node.NodeDialogPane;
 import org.knime.core.node.NodeView;
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
@@ -61,11 +63,11 @@ import org.knime.knip.base.node.XMLNodeUtils;
 import org.knime.knip.base.nodes.io.kernel.structuring.BoxConfiguration;
 import org.knime.knip.base.nodes.io.kernel.structuring.SphereConfiguration;
 import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument;
 
 /**
  * TODO Auto-generated
- * 
+ *
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
@@ -80,11 +82,16 @@ public class StructuringElementNodeFactory<T extends RealType<T>> extends Dynami
 
     /**
      * {@inheritDoc}
+     * @return
      */
     @Override
-    protected void addNodeDescription(final KnimeNodeDocument doc) {
+    protected NodeDescription createNodeDescription() {
+        final KnimeNodeDocument doc = KnimeNodeDocument.Factory.newInstance();
+
         XMLNodeUtils.addXMLNodeDescriptionTo(doc, getClass());
         TableCellViewNodeView.addViewDescriptionTo(doc.getKnimeNode().addNewViews());
+
+        return new NodeDescription210Proxy(doc);
 
     }
 

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/misc/splitter/UCSplitterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/misc/splitter/UCSplitterNodeFactory.java
@@ -75,12 +75,9 @@ import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.GenericValueToCellNodeFactory;
 import org.knime.knip.base.node.ValueToCellNodeDialog;
 import org.knime.knip.base.node.ValueToCellNodeModel;
-import org.knime.knip.base.node.XMLNodeUtils;
 import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
 import org.knime.knip.base.node.nodesettings.SettingsModelDimSelection;
-import org.knime.knip.base.nodes.view.TableCellViewNodeView;
 import org.knime.knip.core.data.img.DefaultImgMetadata;
-import org.knime.node.v210.KnimeNodeDocument;
 
 /**
  *
@@ -93,17 +90,6 @@ public class UCSplitterNodeFactory<T extends RealType<T>> extends
 
     private static SettingsModelDimSelection createDimSelectionModel() {
         return new SettingsModelDimSelection("dim_selection", "X", "Y");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void createNodeDescription(final KnimeNodeDocument doc) {
-        XMLNodeUtils.addXMLNodeDescriptionTo(doc, getClass());
-        //     TODO: Add correct description   ValueToCellNodeDialog.addTabsDescriptionTo(doc.getKnimeNode().getFullDescription());
-        TableCellViewNodeView.addViewDescriptionTo(doc.getKnimeNode().addNewViews());
-
     }
 
     /**

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/misc/splitter/UCSplitterNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/misc/splitter/UCSplitterNodeFactory.java
@@ -67,14 +67,12 @@ import net.imglib2.type.numeric.RealType;
 import org.knime.core.data.DataType;
 import org.knime.core.data.collection.CollectionCellFactory;
 import org.knime.core.data.collection.ListCell;
-import org.knime.core.node.DynamicNodeFactory;
 import org.knime.core.node.ExecutionContext;
-import org.knime.core.node.NodeDialogPane;
-import org.knime.core.node.NodeView;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.knip.base.data.img.ImgPlusCell;
 import org.knime.knip.base.data.img.ImgPlusCellFactory;
 import org.knime.knip.base.data.img.ImgPlusValue;
+import org.knime.knip.base.node.GenericValueToCellNodeFactory;
 import org.knime.knip.base.node.ValueToCellNodeDialog;
 import org.knime.knip.base.node.ValueToCellNodeModel;
 import org.knime.knip.base.node.XMLNodeUtils;
@@ -82,7 +80,7 @@ import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
 import org.knime.knip.base.node.nodesettings.SettingsModelDimSelection;
 import org.knime.knip.base.nodes.view.TableCellViewNodeView;
 import org.knime.knip.core.data.img.DefaultImgMetadata;
-import org.knime.node2012.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument;
 
 /**
  *
@@ -91,7 +89,7 @@ import org.knime.node2012.KnimeNodeDocument;
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
  */
 public class UCSplitterNodeFactory<T extends RealType<T>> extends
-        DynamicNodeFactory<ValueToCellNodeModel<ImgPlusValue<T>, ListCell>> {
+        GenericValueToCellNodeFactory<ImgPlusValue<T>, ValueToCellNodeModel<ImgPlusValue<T>, ListCell>> {
 
     private static SettingsModelDimSelection createDimSelectionModel() {
         return new SettingsModelDimSelection("dim_selection", "X", "Y");
@@ -101,7 +99,7 @@ public class UCSplitterNodeFactory<T extends RealType<T>> extends
      * {@inheritDoc}
      */
     @Override
-    protected void addNodeDescription(final KnimeNodeDocument doc) {
+    protected void createNodeDescription(final KnimeNodeDocument doc) {
         XMLNodeUtils.addXMLNodeDescriptionTo(doc, getClass());
         //     TODO: Add correct description   ValueToCellNodeDialog.addTabsDescriptionTo(doc.getKnimeNode().getFullDescription());
         TableCellViewNodeView.addViewDescriptionTo(doc.getKnimeNode().addNewViews());
@@ -112,7 +110,7 @@ public class UCSplitterNodeFactory<T extends RealType<T>> extends
      * {@inheritDoc}
      */
     @Override
-    protected NodeDialogPane createNodeDialogPane() {
+    protected ValueToCellNodeDialog<ImgPlusValue<T>> createNodeDialog() {
         return new ValueToCellNodeDialog<ImgPlusValue<T>>() {
 
             @Override
@@ -187,31 +185,6 @@ public class UCSplitterNodeFactory<T extends RealType<T>> extends
                 m_imgCellFactory = new ImgPlusCellFactory(exec);
             }
         };
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public NodeView<ValueToCellNodeModel<ImgPlusValue<T>, ListCell>>
-            createNodeView(final int viewIndex, final ValueToCellNodeModel<ImgPlusValue<T>, ListCell> nodeModel) {
-        return new TableCellViewNodeView<ValueToCellNodeModel<ImgPlusValue<T>, ListCell>>(nodeModel);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected int getNrNodeViews() {
-        return 1;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected boolean hasDialog() {
-        return true;
     }
 
 }

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/InvertNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/InvertNodeFactory.java
@@ -67,9 +67,9 @@ import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.ValueToCellNodeDialog;
 import org.knime.knip.base.node.ValueToCellNodeFactory;
 import org.knime.knip.base.node.ValueToCellNodeModel;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * Factory class to produce an image inverter node.

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/InverterNodeFactory2.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/InverterNodeFactory2.java
@@ -66,9 +66,9 @@ import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.IterableIntervalsNodeDialog;
 import org.knime.knip.base.node.IterableIntervalsNodeFactory;
 import org.knime.knip.base.node.IterableIntervalsNodeModel;
-import org.knime.node2012.FullDescriptionDocument.FullDescription;
-import org.knime.node2012.KnimeNodeDocument;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.FullDescriptionDocument.FullDescription;
+import org.knime.node.v210.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * Factory class to produce an image inverter node.

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/ThresholderNodeFactory2.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/ThresholderNodeFactory2.java
@@ -90,7 +90,7 @@ import org.knime.knip.core.algorithm.types.ThresholdingType;
 import org.knime.knip.core.ops.interval.AutoThreshold;
 import org.knime.knip.core.util.EnumUtils;
 import org.knime.knip.core.util.ImgUtils;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * Deprecated. Use ROI based ThresholderNodeFactory3 (ImgThresholder)

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/maxfinder/MaximumFinderNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/maxfinder/MaximumFinderNodeFactory.java
@@ -69,7 +69,7 @@ import org.knime.knip.base.node.ImgPlusToImgPlusNodeDialog;
 import org.knime.knip.base.node.ImgPlusToImgPlusNodeFactory;
 import org.knime.knip.base.node.ImgPlusToImgPlusNodeModel;
 import org.knime.knip.base.node.dialog.DialogComponentDimSelection;
-import org.knime.node2012.KnimeNodeDocument.KnimeNode;
+import org.knime.node.v210.KnimeNodeDocument.KnimeNode;
 
 /**
  * {@link NodeFactory} containint {@link NodeModel} and {@link NodeDialog} for {@link MaximumFinderOp}

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/colormanager/ApplyColorSettingsToLabelsNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/colormanager/ApplyColorSettingsToLabelsNodeFactory.java
@@ -50,6 +50,8 @@
 package org.knime.knip.base.nodes.seg.colormanager;
 
 import org.knime.core.node.DynamicNodeFactory;
+import org.knime.core.node.NodeDescription;
+import org.knime.core.node.NodeDescription210Proxy;
 import org.knime.core.node.NodeDialogPane;
 import org.knime.core.node.NodeView;
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
@@ -58,7 +60,7 @@ import org.knime.core.node.defaultnodesettings.DialogComponentColumnNameSelectio
 import org.knime.knip.base.data.labeling.LabelingValue;
 import org.knime.knip.base.node.XMLNodeUtils;
 import org.knime.knip.base.nodes.view.TableCellViewNodeView;
-import org.knime.node2012.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument;
 
 /**
  * NodeFactory to {@link ApplyColorSettingsToLabelsNodeFactory}
@@ -81,13 +83,18 @@ public class ApplyColorSettingsToLabelsNodeFactory<L extends Comparable<L>> exte
 
     /**
      * {@inheritDoc}
+     * @return
      * @deprecated
      */
     @Deprecated
     @Override
-    protected void addNodeDescription(final KnimeNodeDocument doc) {
+    protected NodeDescription createNodeDescription() {
+        final KnimeNodeDocument doc = KnimeNodeDocument.Factory.newInstance();
+
         XMLNodeUtils.addXMLNodeDescriptionTo(doc, getClass());
         TableCellViewNodeView.addViewDescriptionTo(doc.getKnimeNode().addNewViews());
+
+        return new NodeDescription210Proxy(doc);
     }
 
     /**

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeFactory.java
@@ -49,16 +49,21 @@
 package org.knime.knip.base.nodes.view;
 
 import org.knime.core.node.DynamicNodeFactory;
+import org.knime.core.node.NodeDescription;
+import org.knime.core.node.NodeDescription210Proxy;
 import org.knime.core.node.NodeDialogPane;
 import org.knime.core.node.NodeView;
 import org.knime.knip.base.node.XMLNodeUtils;
-import org.knime.node2012.KnimeNodeDocument;
+import org.knime.node.v210.KnimeNodeDocument;
 
 /**
- * 
+ * Factory for {@link TableCellViewNodeModel}.
+ *
+ *
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
  */
 public class TableCellViewNodeFactory extends DynamicNodeFactory<TableCellViewNodeModel> {
 
@@ -66,9 +71,13 @@ public class TableCellViewNodeFactory extends DynamicNodeFactory<TableCellViewNo
      * {@inheritDoc}
      */
     @Override
-    protected void addNodeDescription(final KnimeNodeDocument doc) {
+    protected NodeDescription createNodeDescription() {
+        final KnimeNodeDocument doc = KnimeNodeDocument.Factory.newInstance();
+
         XMLNodeUtils.addXMLNodeDescriptionTo(doc, this.getClass());
         TableCellViewNodeView.addViewDescriptionTo(doc.getKnimeNode().addNewViews());
+
+        return new NodeDescription210Proxy(doc);
     }
 
     /**
@@ -93,7 +102,7 @@ public class TableCellViewNodeFactory extends DynamicNodeFactory<TableCellViewNo
      */
     @Override
     public NodeView<TableCellViewNodeModel> createNodeView(final int viewIndex, final TableCellViewNodeModel nodeModel) {
-        return new TableCellViewNodeView(nodeModel);
+        return new TableCellViewNodeView<>(nodeModel);
     }
 
     /**

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java
@@ -169,6 +169,37 @@ public class TableCellViewNodeView<T extends NodeModel & BufferedDataTableHolder
 
     }
 
+    /**
+     * Add the description of the view.
+     *
+     * @param views
+     *
+     * @deprecated Consider using {@link org.knime.node.v210.ViewsDocument.Views}
+     */
+    @Deprecated
+    public static void addViewDescriptionTo(final org.knime.node2012.ViewsDocument.Views views) {
+        final org.knime.node2012.ViewDocument.View view = views.addNewView();
+        view.setIndex(0);
+        view.setName("Table Cell View");
+
+        final Map<Class<? extends DataValue>, List<String>> descs =
+                TableCellViewsManager.getInstance().getTableCellViewDescriptions();
+        view.newCursor()
+                .setTextValue("Another, possibly interactive, view on table cells. Displays the selected cells with their associated viewer if it exists. Available views are:");
+        view.addNewBr();
+        for (final Entry<Class<? extends DataValue>, List<String>> entry : descs.entrySet()) {
+
+            view.addB("- " + entry.getKey().getSimpleName());
+            view.addNewBr();
+            for (final String d : entry.getValue()) {
+                view.addI("-- " + d);
+                view.addNewBr();
+            }
+
+        }
+
+    }
+
     protected Map<String, List<TableCellView>> m_cellViews;
 
     protected JTabbedPane m_cellViewTabs;

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java
@@ -136,6 +136,9 @@ import org.knime.node.v210.ViewsDocument.Views;
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael Zinsmaier</a>
+ * @author <a href="mailto:jonathan.hale@uni.kn">Jonathan Hale</a>
+ *
+ * @param <T> {@link NodeModel} subclass this {@link TableCellViewNodeView} belongs to.
  */
 public class TableCellViewNodeView<T extends NodeModel & BufferedDataTableHolder> extends NodeView<T> {
 

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java
@@ -50,6 +50,7 @@ package org.knime.knip.base.nodes.view;
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,8 +77,8 @@ import org.knime.core.node.tableview.TableContentModel;
 import org.knime.core.node.tableview.TableContentView;
 import org.knime.core.node.tableview.TableView;
 import org.knime.knip.core.util.waitingindicator.WaitingIndicatorUtils;
-import org.knime.node2012.ViewDocument.View;
-import org.knime.node2012.ViewsDocument.Views;
+import org.knime.node.v210.ViewDocument.View;
+import org.knime.node.v210.ViewsDocument.Views;
 
 /*
  * ------------------------------------------------------------------------
@@ -147,7 +148,7 @@ public class TableCellViewNodeView<T extends NodeModel & BufferedDataTableHolder
      */
     public static void addViewDescriptionTo(final Views views) {
         final View view = views.addNewView();
-        view.setIndex(0);
+        view.setIndex(new BigInteger("0"));
         view.setName("Table Cell View");
 
         final Map<Class<? extends DataValue>, List<String>> descs =

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java.orig
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/view/TableCellViewNodeView.java.orig
@@ -76,8 +76,8 @@ import org.knime.core.node.tableview.TableContentModel;
 import org.knime.core.node.tableview.TableContentView;
 import org.knime.core.node.tableview.TableView;
 import org.knime.knip.core.util.waitingindicator.WaitingIndicatorUtils;
-import org.knime.node2012.ViewDocument.View;
-import org.knime.node2012.ViewsDocument.Views;
+import org.knime.node.v210.ViewDocument.View;
+import org.knime.node.v210.ViewsDocument.Views;
 
 /*
  * ------------------------------------------------------------------------


### PR DESCRIPTION
Via some recent issues with the Tess4JNodeFactory.xml I realized that most of KNIP still uses the node2012 xml scheme.

The changes in this PR would update all of org.knime.knip.base to the new node descriptions, but breaks backwards compatibility, since we use classes from `org.knime.node.v210.*` instead of `org.knime.node2012` now which have the same names, but do not have a common interface.
This also means that IJMacroNodeFactory for example (and probably all other NodeFactories extending `GenericValueToCellNodeFactory`(and similar)) would have compile errors until moved to v210.

A solution would be to revert changes to the old (Two)Value(s)ToCell(s)NodeFactory classes, deprecate them and create new API, to which we move all the Nodes we maintain. Another solution would be to wait until a major knip release which is allowed to break the API.

@dietzc What do you say? (The refactor of the (Two)Value(s)ToCell(s)NodeFactory classes works without the upgrade of node descriptions btw, so we can have that anyway.)

