### PR TITLE
bump knime version

### DIFF
--- a/org.knime.knip.base/META-INF/MANIFEST.MF
+++ b/org.knime.knip.base/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-ManifestVersion: 2
 Bundle-Version: 1.3.0.qualifier
 Bundle-Vendor: University of Konstanz
 Eclipse-RegisterBuddy: org.knime.core
-Require-Bundle: org.knime.base;bundle-version="[2.10.0,3.0.0)",
- org.knime.workbench.repository;bundle-version="[2.10.0,3.0.0)",
+Require-Bundle: org.knime.base;bundle-version="[3.0.0,4.0.0)",
+ org.knime.workbench.repository;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.ui;bundle-version="3.6.0",
  imglib2;bundle-version="2.3.0",

--- a/org.knime.knip.io/META-INF/MANIFEST.MF
+++ b/org.knime.knip.io/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-Version: 1.3.0.qualifier
 Eclipse-BuddyPolicy: registered
 Eclipse-RegisterBuddy: org.knime.knip.scijava
 Bundle-Vendor: University of Konstanz
-Require-Bundle: org.knime.base;bundle-version="[2.10.0,3.0.0)",
- org.knime.workbench.repository;bundle-version="[2.10.0,3.0.0)",
+Require-Bundle: org.knime.base;bundle-version="[3.0.0,4.0.0)",
+ org.knime.workbench.repository;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.ui;bundle-version="3.6.0",
  imglib2;bundle-version="2.3.0",

--- a/org.knime.knip.testing/META-INF/MANIFEST.MF
+++ b/org.knime.knip.testing/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-ManifestVersion: 2
 Bundle-Version: 1.3.0.qualifier
 Bundle-Vendor: University of Konstanz
 Eclipse-RegisterBuddy: org.knime.core
-Require-Bundle: org.knime.base;bundle-version="[2.10.0,3.0.0)",
- org.knime.workbench.repository;bundle-version="[2.10.0,3.0.0)",
+Require-Bundle: org.knime.base;bundle-version="[3.0.0,4.0.0)",
+ org.knime.workbench.repository;bundle-version="[3.0.0,4.0.0)",
  org.apache.log4j;bundle-version="1.2.15",
  org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/org.knime.knip.tracking/META-INF/MANIFEST.MF
+++ b/org.knime.knip.tracking/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-ManifestVersion: 2
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: University of Konstanz
 Eclipse-RegisterBuddy: org.knime.core
-Require-Bundle: org.knime.base;bundle-version="[2.10.0,3.0.0)",
- org.knime.workbench.repository;bundle-version="[2.10.0,3.0.0)",
+Require-Bundle: org.knime.base;bundle-version="[3.0.0,4.0.0)",
+ org.knime.workbench.repository;bundle-version="[3.0.0,4.0.0)",
  org.apache.log4j;bundle-version="1.2.15",
  org.eclipse.core.runtime,
  org.eclipse.ui,


### PR DESCRIPTION
Increase the required KNIME version to 3.0.0.
Makes it compatible with the nightly target definition in `knip-sdk-setup`