### PR TITLE
revert img reader to last release version and deprecate it

### DIFF
--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/FileChooserPanel.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/FileChooserPanel.java
@@ -62,7 +62,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -706,13 +705,6 @@ public class FileChooserPanel extends JPanel {
             m_fileChooser.setFileFilter(m_fileChooser.getAcceptAllFileFilter());
             return;
         }
-        
-		// if a path to a directory was entered, jump to directory
-		File f = new File(text);
-		if (f.exists() && f.isDirectory()) {
-			m_fileChooser.setCurrentDirectory(f);
-			return;
-		}
 
         final File[] dirFiles = m_fileChooser.getCurrentDirectory().listFiles();
         final ArrayList<String> textFiles = new ArrayList<String>();
@@ -847,9 +839,6 @@ public class FileChooserPanel extends JPanel {
 
     private void onAddAllTopLevelFiles() {
         final File[] files = m_fileChooser.getCurrentDirectory().listFiles();
-        
-        Arrays.sort(files);
-        
         final ArrayList<File> topLevelFiles = new ArrayList<File>();
 
         // remove directories

--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/ImgReaderNodeFactory.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/ImgReaderNodeFactory.java
@@ -58,7 +58,7 @@ import org.knime.knip.base.nodes.view.TableCellViewNodeView;
 
 /**
  * The Factory class for the Image Reader.
- *
+ * 
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael

--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/ImgReaderNodeFactory.xml
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/ImgReaderNodeFactory.xml
@@ -5,36 +5,19 @@
 	Contributors: IBM Corporation - initial API and implementation -->
 
 <!DOCTYPE knimeNode PUBLIC "-//UNIKN//DTD KNIME Node 2.0//EN" "http://www.knime.org/Node.dtd">
-<knimeNode icon="imgreader.png" type="Source">
-	<name>Image Reader (Deprecated)</name>
+<knimeNode icon="imgreader.png" type="Source" deprecated="true">
+	<name>Image Reader</name>
 	<shortDescription>
-		This image reader is deprecated! We splitted the
-		functionality into two new image reader nodes, one which only reads
-		files which are selected from a dialog called 'Image Reader' and a
-		second one which only
-		reads files from an input table called 'Image
-		Reader (Table)'.
-
-
 		Reads images from possibly different directories and
 		imports them to the
 		KNIME-internal image format. The images will be
-		read an as
-		PlanarImages, which means that they are optimized for the
-		access of the
-		first two dimensions. To convert them to another image
-		format (ArrayImg
-		if you want to process the whole image at once)
-		please
-		make use of
-		the
-		converter node.
-
-		Image can also be downloaded and read
-		from URLs (e.g.
-		http://...). The URLs have to be provided via the input
-		table (as
-		strings).
+		read an as PlanarImages, which means that they are optimized for the
+		access of the first two dimensions. To convert them to another image
+		format (ArrayImg if you want to process the whole image at once)
+		please make use of
+		the converter node.
+		
+		Image can also be downloaded and read from URLs (e.g. http://...). The URLs have to be provided via the input table (as strings). 
 	</shortDescription>
 
 	<fullDescription>
@@ -43,11 +26,9 @@
 			library and imports them to the KNIME-internal image format.
 			A list of
 			the supported formats can be found here:
-			<a href="http://loci.wisc.edu/bio-formats/formats">http://loci.wisc.edu/bio-formats/formats</a>
-			.
-
-			Image can also be downloaded and read from URLs (e.g. http://...).
-			The URLs have to be provided via the input table (as strings).
+			<a href="http://loci.wisc.edu/bio-formats/formats">http://loci.wisc.edu/bio-formats/formats</a>.
+			
+			Image can also be downloaded and read from URLs (e.g. http://...). The URLs have to be provided via the input table (as strings).
 		</intro>
 		<tab name="Options">
 			<option name="File browser">
@@ -62,21 +43,13 @@
 			</option>
 		</tab>
 		<tab name="Additional Options">
-			<option name="OME-XML-metadata">
-				You can either add a column containing the metadata formated as
+			<option name="Append additional OME-XML-metadata column">
+				You can add a column containing the metadata formated as
 				an
-				OML-XML-String, read only the metadata from the images files, or
-				just read the
-				images (default).
-				(for more details see:
+				OME-XML-String
+				(more details on
 				<a href="http://www.ome-xml.org/">http://www.ome-xml.org/</a>
 				).
-			</option>
-			<option name="Read non OME-XML Metadata">
-				Read metadata that is not part of the ome-xml
-				specification.
-				It will be appended as XML annotation to the ome-xml
-				metadata.
 			</option>
 			<option name="Image Factory">Defines the way how the images are created and
 				therewith kept in memory: Array Image Factory (stored as ONE array;
@@ -85,33 +58,26 @@
 				are read faster; cons: limited number of pixels in an XY-plane,
 				slower pixel access), and Cell Image Factory (multiple arrays of
 				fixed sizes are used, pros: unlimited number of pixels per images;
-				cons: very slow pixel reading and pixel access))
-			</option>
+				cons: very slow pixel reading and pixel access))</option>
 			<option name="Use complete file path as row key">
 				If checked, the complete file path will be used
 				as
 				row key, else only
-				the file name. Has no effect, if images are read
-				from URLs.
-			</option>
+				the file name. Has no effect, if images are read from URLs.</option>
 			<option name="Check file format for each file">Checks for each file individually the
 				file-format, if checked. Else, the file format as assumed to be the
 				same for all files and only if the reading fails, the new file
-				format will be determined.
-			</option>
+				format will be determined.</option>
 			<option name="File name column in optional table">If another node with a string column is plugged
 				to the optional in-port, the column, which contains the potential
-				file paths, can be selected.
-			</option>
+				file paths, can be selected.</option>
 			<option name="Read all series">Some image file formats might contain multiple
 				images (called series). One can either read all available series
-				(each appended as own table row) or just one series with the
-				specified
+				(each appended as own table row) or just one series with the specified
 				index ("Series index").
 			</option>
 			<option name="Load group files">If selected, related group files will be read as
-				well.
-			</option>
+				well.</option>
 
 		</tab>
 		<tab name="Subset Selection">
@@ -125,59 +91,39 @@
 				individual
 				dimensions can be obtained from the
 				image metadata.
-
-				<p>Alternatively, selecting subsets can be done in three ways using
-					the text field below each selection list:
-				</p>
-
-				<p>
-					<b>Discrete Element Selection</b>
-					Every element that shall be selected can
-					be entered on it's own,
-					separated by commas.
-					e.g. "1, 5, 8, 9"
-				</p>
-				<p>
-					<b>Cohesive Element Selection</b>
-					Selecting a complete region "from" a given
-					value "to" another can be
-					done by putting a
-					hyphen between two values, marking the first
-					as the
-					region start and the second as the end.
-					Comma-separation still holds
-					and can separate
-					either complete regions, or regions and discrete
-					selections.
-					e.g. 1-5, 8-10, 11
-				</p>
-				<p>
-					<b>Function Based Selection</b>
-					Selection values based on a given function
-					can be done by marking
-					the function with a
-					leading "f=" and entering the desired
-					functionality thereafter. Any single variable
-					function or constant
-					contained within the
-					javascript math package can be used with
-					standard javascript syntax.
-					(e.g. math.pow(2, i) for selecting 2, 4,
-					8,...)
-				</p>
-				<p>
-					<b>Combining</b>
-					The above mentioned functionalities can be
-					arbitrarily intermingled
-					as every comma separated
-					entry is read and interpreted on it's own.
-					e.g. Selecting all Values from 1-10, every eleventh
-					entry and the
-					twentieth entry for some reason can
-					be done by entering:
-					"1-10, 20,
-					f=11*i"
-				</p>
+				
+				<p>Alternatively, selecting subsets can be done in three ways using the text field below each selection list:</p>
+								
+				<p><b>Discrete Element Selection</b>
+				Every element that shall be selected can 
+				be entered on it's own, separated by commas.
+				e.g. "1, 5, 8, 9"</p>
+				<p><b>Cohesive Element Selection</b>
+				Selecting a complete region "from" a given
+				value "to" another can be done by putting a
+				hyphen between two values, marking the first
+				as the region start and the second as the end.
+				Comma-separation still holds and can separate
+				either complete regions, or regions and discrete
+				selections.
+				e.g. 1-5, 8-10, 11</p>
+				<p><b>Function Based Selection</b>
+				Selection values based on a given function 
+				can be done by marking the function with a
+				leading "f=" and entering the desired 
+				functionality thereafter. Any single variable
+				function or constant contained within the 
+				javascript math package can be used with 
+				standard javascript syntax. 
+				(e.g. math.pow(2, i) for selecting 2, 4, 8,...)</p>
+				<p><b>Combining</b>
+				The above mentioned functionalities can be 
+				arbitrarily intermingled as every comma separated
+				entry is read and interpreted on it's own.
+				e.g. Selecting all Values from 1-10, every eleventh 
+				entry and the twentieth entry for some reason can
+				be done by entering:
+				"1-10, 20, f=11*i"	</p>			
 			</option>
 		</tab>
 
@@ -185,8 +131,7 @@
 
 	<ports>
 		<inPort name="File names (optional)" index="0">Optional input table
-			with a column containing the file names/paths.
-		</inPort>
+			with a column containing the file names/paths.</inPort>
 		<outPort index="0" name="Images">
 			The opened images and optionally a
 			column with the metadata.

--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/ImgReaderNodeModel.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/imgreader/ImgReaderNodeModel.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * ------------------------------------------------------------------------
+ *
  *  Copyright (C) 2003 - 2013
  *  University of Konstanz, Germany and
  *  KNIME GmbH, Konstanz, Germany
@@ -80,17 +82,14 @@ import org.knime.core.node.defaultnodesettings.SettingsModelString;
 import org.knime.core.node.defaultnodesettings.SettingsModelStringArray;
 import org.knime.core.node.port.PortType;
 import org.knime.knip.base.node.nodesettings.SettingsModelSubsetSelection;
-import org.knime.knip.core.util.EnumUtils;
-import org.knime.knip.io.nodes.imgreader.ImgReaderSettingsModels.MetadataMode;
 
 /**
  * This Node reads images.
- *
+ * 
  * @author <a href="mailto:dietzc85@googlemail.com">Christian Dietz</a>
  * @author <a href="mailto:horn_martin@gmx.de">Martin Horn</a>
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael
  *         Zinsmaier</a>
- * @author <a href="mailto:gabriel.einsdorf@uni.kn"> Gabriel Einsdorf</a>
  */
 public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 		NodeModel implements BufferedDataTableHolder {
@@ -134,6 +133,7 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 						m_currentIt++;
 						return hasNext();
 					}
+
 				}
 
 				@Override
@@ -151,51 +151,121 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 		}
 	}
 
-	private final SettingsModelBoolean m_checkFileFormat = ImgReaderSettingsModels
-			.createCheckFileFormatModel();
+	/**
+	 * Key to store the check file format option.
+	 */
+	public static final String CFG_CHECK_FILE_FORMAT = "check_file_format";
 
-	private final SettingsModelBoolean m_completePathRowKey = ImgReaderSettingsModels
-			.createCompletePathRowKeyModel();
+	/**
+	 * Key to store if the complete path should be used as row key
+	 */
+	public static final String CFG_COMPLETE_PATH_ROWKEY = "complete_path_rowkey";
+
+	/**
+	 * Key to store the directory history.
+	 */
+	public static final String CFG_DIR_HISTORY = "imagereader_dirhistory";
+
+	/**
+	 * Key for the settings holding the file list.
+	 */
+	public static final String CFG_FILE_LIST = "file_list";
+
+	/**
+	 * Key to store the selected column in the optional input table
+	 */
+	public static final String CFG_FILENAME_COLUMN = "filename_column";
+
+	/**
+	 * Key for the settings holding information if group files modus is wanted
+	 */
+	public static final String CFG_GROUP_FILES = "group_files";
+
+	/**
+	 * Key to store the OME_XML-metadata column option.
+	 */
+	public static final String CFG_OME_XML_METADATA_COLUMN = "xmlcolumns";
+
+	/**
+	 * Key to store the factory used to create the images
+	 */
+	public static final String CFG_IMG_FACTORY = "img_factory";
+
+	/**
+	 * Key to store whether all series should be read
+	 */
+	public static final String CFG_READ_ALL_SERIES = "read_all_series";
+
+	/**
+	 * Key to store the selected series
+	 */
+	public static final String CFG_SERIES_SELECTION = "series_selection";
+
+	/*
+	 * Settings
+	 */
+
+	/**
+	 * Key for the settings holding selected image planes.
+	 */
+	public static final String CFG_PLANE_SLECTION = "plane_selection";
+
+	/**
+	 * The image out port of the Node.
+	 */
+	public static final int IMAGEOUTPORT = 0;
+
+	/**
+	 * The meta data out port of the Node.
+	 */
+	public static final int METADATAOUTPORT = 1;
+
+	/**
+	 * The available factory types available for selection.
+	 */
+	public static final String[] IMG_FACTORIES = new String[] {
+			"Array Image Factory", "Planar Image Factory", "Cell Image Factory" };
+
+	private final SettingsModelBoolean m_checkFileFormat = new SettingsModelBoolean(
+			CFG_CHECK_FILE_FORMAT, true);
+
+	private final SettingsModelBoolean m_completePathRowKey = new SettingsModelBoolean(
+			CFG_COMPLETE_PATH_ROWKEY, false);
 
 	/* data table for the table cell viewer */
 	private BufferedDataTable m_data;
 
-	private final SettingsModelString m_filenameColumn = ImgReaderSettingsModels
-			.createFilenameColumnModel();
+	private final SettingsModelString m_filenameCol = new SettingsModelString(
+			CFG_FILENAME_COLUMN, "");
 
 	/*
 	 * Collection of all settings.
 	 */
 
-	private final SettingsModelStringArray m_files = ImgReaderSettingsModels
-			.createFileListModel();
-	// New in 1.0.2
-	private final SettingsModelBoolean m_isGroupFiles = ImgReaderSettingsModels
-			.createIsGroupFilesModel();
+	private final SettingsModelStringArray m_files = new SettingsModelStringArray(
+			CFG_FILE_LIST, new String[] {});
 
-	private final SettingsModelSubsetSelection m_planeSelect = ImgReaderSettingsModels
-			.createPlaneSelectionModel();
+	// New in 1.0.2
+	private final SettingsModelBoolean m_isGroupFiles = new SettingsModelBoolean(
+			CFG_GROUP_FILES, true);
+
+	private final SettingsModelBoolean m_omexmlCol = new SettingsModelBoolean(
+			CFG_OME_XML_METADATA_COLUMN, false);
+
+	private final SettingsModelSubsetSelection m_planeSelect = new SettingsModelSubsetSelection(
+			CFG_PLANE_SLECTION);
 
 	// new in 1.1
-	private final SettingsModelString m_imgFactory = ImgReaderSettingsModels
-			.createImgFactoryModel();
+	private final SettingsModelString m_imgFactory = new SettingsModelString(
+			CFG_IMG_FACTORY, IMG_FACTORIES[0]);
 
-	private SettingsModelBoolean m_readAllSeries = ImgReaderSettingsModels
-			.createReadAllSeriesModel();
+	private SettingsModelBoolean m_readAllSeries = new SettingsModelBoolean(
+			CFG_READ_ALL_SERIES, true);
 
-	private final SettingsModelIntegerBounded m_seriesSelection = ImgReaderSettingsModels
-			.createSeriesSelectionModel();
-
-	// new in 1.3
-	private final SettingsModelString m_metadataModeModel = ImgReaderSettingsModels
-			.createMetaDataModeModel();
-
-	private final SettingsModelBoolean m_readAllMetaDataModel = ImgReaderSettingsModels
-			.createReadAllMetaDataModel();
+	private final SettingsModelIntegerBounded m_seriesSelection = new SettingsModelIntegerBounded(
+			CFG_SERIES_SELECTION, 0, 0, 1000);
 
 	private final Collection<SettingsModel> m_settingsCollection;
-
-	private MetadataMode m_metadataMode;
 
 	/**
 	 * Initializes the ImageReader
@@ -206,7 +276,8 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 		m_settingsCollection = new ArrayList<SettingsModel>();
 		m_settingsCollection.add(m_files);
 		m_settingsCollection.add(m_planeSelect);
-		m_settingsCollection.add(m_filenameColumn);
+		m_settingsCollection.add(m_omexmlCol);
+		m_settingsCollection.add(m_filenameCol);
 		m_settingsCollection.add(m_completePathRowKey);
 		m_settingsCollection.add(m_checkFileFormat);
 
@@ -223,26 +294,8 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 	protected DataTableSpec[] configure(final DataTableSpec[] inSpecs)
 			throws InvalidSettingsException {
 
-		m_metadataMode = EnumUtils.valueForName(
-				m_metadataModeModel.getStringValue(), MetadataMode.values());
-		final ReadFileImgTable<T> tab = new ReadFileImgTable<T>(m_metadataMode);
-
-		String column = m_filenameColumn.getStringValue();
-		// optional input configured
-		if (column != null && !column.equals("") && !column.equals("URL")) { 
-			// previously connected`
-			if (inSpecs[0] == null) {
-				throw new InvalidSettingsException(
-						"Optional input is configured but disconected");
-			}
-			// column no longer avaiable
-			if(!inSpecs[0].containsName(m_filenameColumn.getStringValue())) {
-				throw new InvalidSettingsException("The configured column: '"
-						+ m_filenameColumn.getStringValue()
-						+ "' is no longer avaiable!");
-			}
-		}
-
+		final ReadFileImgTable<T> tab = new ReadFileImgTable<T>(
+				m_omexmlCol.getBooleanValue());
 		// tab.setDimLabelProperty(m_planeSelect.getDimLabelsAsString());
 		return new DataTableSpec[] { tab.getDataTableSpec() };
 	}
@@ -256,8 +309,8 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 			final ExecutionContext exec) throws Exception {
 		final String[] fnames = m_files.getStringArrayValue();
 
-		m_metadataMode = EnumUtils.valueForName(
-				m_metadataModeModel.getStringValue(), MetadataMode.values());
+		// String[] metaDataColumns =
+		// m_metadatakeys.getStringArrayValue();
 
 		// table with images from the dialog
 		Iterable<String> tableImgList = null;
@@ -265,7 +318,7 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 
 		if (inData[0] != null) {
 			final int colIdx = inData[0].getDataTableSpec().findColumnIndex(
-					m_filenameColumn.getStringValue());
+					m_filenameCol.getStringValue());
 			if (colIdx >= 0) {
 				tableImgList = new Iterable<String>() {
 					@Override
@@ -297,6 +350,7 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 						};
 					}
 				};
+
 			}
 
 		}
@@ -319,11 +373,9 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 
 		// create ImgFactory
 		ImgFactory<T> imgFac;
-		if (m_imgFactory.getStringValue().equals(
-				ImgReaderSettingsModels.IMG_FACTORIES[1])) {
+		if (m_imgFactory.getStringValue().equals(IMG_FACTORIES[1])) {
 			imgFac = new PlanarImgFactory<T>();
-		} else if (m_imgFactory.getStringValue().equals(
-				ImgReaderSettingsModels.IMG_FACTORIES[2])) {
+		} else if (m_imgFactory.getStringValue().equals(IMG_FACTORIES[2])) {
 			// TODO: what is the appropriate cell size?
 			imgFac = new CellImgFactory<T>();
 		} else {
@@ -340,8 +392,7 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 
 		// create data table
 		final ReadFileImgTable<T> dt = new ReadFileImgTable<T>(exec, imgIt,
-				numImages, m_planeSelect, m_metadataMode,
-				m_readAllMetaDataModel.getBooleanValue(),
+				numImages, m_planeSelect, m_omexmlCol.getBooleanValue(),
 				m_checkFileFormat.getBooleanValue(),
 				m_completePathRowKey.getBooleanValue(),
 				m_isGroupFiles.getBooleanValue(), seriesSelection, imgFac);
@@ -420,10 +471,6 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 			m_imgFactory.loadSettingsFrom(settings);
 			m_readAllSeries.loadSettingsFrom(settings);
 			m_seriesSelection.loadSettingsFrom(settings);
-
-			// new in 1.3
-			m_metadataModeModel.loadSettingsFrom(settings);
-			m_readAllMetaDataModel.loadSettingsFrom(settings);
 		} catch (final Exception e) {
 			// nothing to handle
 		}
@@ -445,9 +492,6 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 		m_readAllSeries.saveSettingsTo(settings);
 		m_seriesSelection.saveSettingsTo(settings);
 
-		// new in 1.3
-		m_metadataModeModel.saveSettingsTo(settings);
-		m_readAllMetaDataModel.saveSettingsTo(settings);
 	}
 
 	/**
@@ -468,11 +512,6 @@ public class ImgReaderNodeModel<T extends RealType<T> & NativeType<T>> extends
 			m_imgFactory.validateSettings(settings);
 			m_readAllSeries.validateSettings(settings);
 			m_seriesSelection.validateSettings(settings);
-
-			// new in 1.3
-			m_metadataModeModel.validateSettings(settings);
-			m_readAllMetaDataModel.validateSettings(settings);
-
 		} catch (final Exception e) {
 			// nothing to handle
 		}


### PR DESCRIPTION
this pull requests reverts the img reader to the last release version and deprecates it. all changes since then are included in the two new img reader nodes. issue #164 is resolved by this.