### PR TITLE
Fix Border Labelings Removed in WaehlbySplitter

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
@@ -198,7 +198,7 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         final RandomAccessibleInterval<FloatType> imgAliceExt = Views.interval(Views.extendBorder(imgAlice), img);
         final RandomAccessibleInterval<FloatType> imgBobExt = Views.interval(Views.extendBorder(imgBob), img);
 
-        //Labeling converted to BitType
+        // labeling converted to BitType (background where empty label, foreground where any label)
         final RandomAccessibleInterval<BitType> inLabMasked =
                 Views.interval(new ConvertedRandomAccessible<LabelingType<L>, BitType>(inLab,
                         new LabelingToBitConverter<LabelingType<L>>(), new BitType()), inLab);
@@ -235,7 +235,7 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         final RandomAccessibleInterval<LabelingType<String>> watershedResult =
                 new ImgLabeling<String, ShortType>(new ArrayImgFactory<ShortType>().create(img, new ShortType()));
 
-        // seeded watershed
+        /* seeded watershed */
         m_watershed.compute(invertImg(imgAlice, new FloatType()), seeds, watershedResult);
 
         // use the sheds from the watershed to split the labeled objects
@@ -248,16 +248,16 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         final ArrayList<String> labels = new ArrayList<String>(regions.getExistingLabels());
         Collections.sort(labels, (o1, o2) -> o1.compareTo(o2) * -1);
 
-        // get some more information about the objects. Contour, bounding box etc
+        /* get some more information about the objects. Contour, bounding box etc */
         for (final String label : labels) {
 
             final IterableInterval<LabelingType<String>> intervalOverSrc =
                     Regions.sample(regions.getLabelRegion(label), watershedResult);
 
-            // create individual images for every object
+            /* create individual images for every object */
             final ExtendedPolygon poly = new ExtendedPolygon();
 
-            // compute contour polygon
+            /* compute contour polygon */
             contourExtraction.compute(regions.getLabelRegion(label), poly);
 
             objects.add(new LabeledObject(poly, label, intervalOverSrc));
@@ -285,7 +285,7 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
                                                                                                                .createVariable()),
                                                                                      watershedResult));
 
-            // find two objects that are closer than rSize
+            /* find two objects that are closer than rSize */
             for (int i = 0; i < objects.size(); ++i) {
                 for (int j = i + 1; j < objects.size(); ++j) {
 

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
@@ -448,6 +448,22 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         return new FinalInterval(new long[]{1, 1}, dims);
     }
 
+    /**
+     * Display the given image for debugging.
+     *
+     * @param img the image to display
+     * @param title title of the window to display in
+     */
+    private void showImage(final Img<FloatType> img, final String title) {
+
+        final IterableIntervalNormalize<FloatType> normalize = new IterableIntervalNormalize<FloatType>(0,
+                new FloatType(), new ValuePair<FloatType, FloatType>(new FloatType(0), new FloatType(1)), false);
+
+        Img<FloatType> normalized = img.factory().create(img, new FloatType());
+        normalize.compute(img, normalized);
+
+        AWTImageTools.showInFrame(normalized, title);
+    }
 
     private final double featureCircularity(final double perimeter, final double roisize) {
         return perimeter / (2.0 * Math.sqrt(Math.PI * roisize));

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
@@ -242,7 +242,6 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         split("Watershed", watershedResult, inLabMasked);
 
         final MooreContourExtractionOp contourExtraction = new MooreContourExtractionOp(true);
-        final ArrayImgFactory<BitType> bitFactory = new ArrayImgFactory<BitType>();
         final ArrayList<LabeledObject> objects = new ArrayList<LabeledObject>();
 
         LabelRegions<String> regions = KNIPGateway.regions().regions(watershedResult);
@@ -371,7 +370,6 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
 
         final RandomAccess<LabelingType<String>> raOut = outLab.randomAccess();
 
-        regions = KNIPGateway.regions().regions(watershedResult);
         // decide whether to merge objects using circularity and size
         for (final Triple<LabeledObject, LabeledObject, String> triple : mergedList) {
             final String label = triple.getThird();
@@ -450,9 +448,6 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         return new FinalInterval(new long[]{1, 1}, dims);
     }
 
-    private final long[] add2D(final long[] a, final long[] b) {
-        return new long[]{a[0] + b[0], a[1] + b[1]};
-    }
 
     private final double featureCircularity(final double perimeter, final double roisize) {
         return perimeter / (2.0 * Math.sqrt(Math.PI * roisize));

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
@@ -411,6 +411,45 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
 
     }
 
+    /**
+     * Create an instance of the labeling type contained in <code>inLab</code> and clear it, resulting in an empty
+     * label.
+     *
+     * @param inLab labeling to get an empty label from.
+     * @return the empty label
+     */
+    private LabelingType<L> getEmptyLabel(final RandomAccessibleInterval<LabelingType<L>> inLab) {
+        final RandomAccess<LabelingType<L>> ra = inLab.randomAccess();
+        ra.fwd(1);
+        final LabelingType<L> labelingType = ra.get();
+        final LabelingType<L> empty = labelingType.copy();
+        empty.clear();
+        return empty;
+    }
+
+    /**
+     * Extend the given interval by 1 in every dimensions (assuming 2 dims).
+     *
+     * @param i interval to extend
+     * @return the extended interval
+     */
+    private FinalInterval extendBorderByOne(final Interval i) {
+        return new FinalInterval(new long[]{i.min(0) - 1, i.min(1) - 1}, new long[]{i.max(0) + 1, i.max(0) + 1});
+    }
+
+    /**
+     * Create an interval which has the same dimensions as the target Dimensions, but offset by 1 in dimensions 0 and 1
+     * to cut off a 1 pixel border.
+     *
+     * @param target size of the result interval.
+     * @return the created interval.
+     */
+    private FinalInterval cutOffBorder(final Dimensions target) {
+        final long[] dims = new long[2];
+        target.dimensions(dims);
+        return new FinalInterval(new long[]{1, 1}, dims);
+    }
+
     private final long[] add2D(final long[] a, final long[] b) {
         return new long[]{a[0] + b[0], a[1] + b[1]};
     }

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/seg/waehlby/WaehlbySplitterOp.java
@@ -187,9 +187,6 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
     /* image factory used in this op TODO: Should use the img factory of the input img */
     private final ArrayImgFactory<FloatType> m_floatFactory = new ArrayImgFactory<FloatType>();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public RandomAccessibleInterval<LabelingType<String>>
            compute(final RandomAccessibleInterval<LabelingType<L>> inLab, final RandomAccessibleInterval<T> img,
@@ -465,18 +462,12 @@ public class WaehlbySplitterOp<L extends Comparable<L>, T extends RealType<T>> i
         return (a * a + b * b);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public BinaryObjectFactory<RandomAccessibleInterval<LabelingType<L>>, RandomAccessibleInterval<T>, RandomAccessibleInterval<LabelingType<String>>>
            bufferFactory() {
         return (lab, in) -> KNIPGateway.ops().create().imgLabeling(lab);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public BinaryOutputOperation<RandomAccessibleInterval<LabelingType<L>>, RandomAccessibleInterval<T>, RandomAccessibleInterval<LabelingType<String>>>
            copy() {

--- a/org.knime.knip.core/.externalToolBuilders/EclipseHelper.launch
+++ b/org.knime.knip.core/.externalToolBuilders/EclipseHelper.launch
@@ -3,6 +3,6 @@
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${system_path:java}"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="-classpath ${project_classpath:org.knime.knip.core} org.scijava.annotations.EclipseHelper"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="-classpath &quot;${project_classpath:org.knime.knip.core}&quot; org.scijava.annotations.EclipseHelper"/>
 <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
 </launchConfiguration>


### PR DESCRIPTION
Hi @dietzc !

As mentioned yesterday, I found the solution to the WaehlbySplitter problem. Since this came up during the KNIME Spring Summit, I decided to give this some time and here it is.

I will quickly reword the commit containing the `@`, an then you may merge.

Regards, Jonathan.
