### PR TITLE
MiscViews Improvements

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/Remove1DimNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/Remove1DimNodeFactory.java
@@ -105,9 +105,6 @@ public class Remove1DimNodeFactory<T extends RealType<T> & NativeType<T>> extend
                     res = MiscViews.cleanImgPlus(fromCell);
                 }
 
-                res.setSource(fromCell.getSource());
-                res.setName(fromCell.getName());
-
                 return m_imgCellFactory.createCell(res);
             }
 

--- a/org.knime.knip.core/src/org/knime/knip/core/util/MiscViews.java
+++ b/org.knime.knip.core/src/org/knime/knip/core/util/MiscViews.java
@@ -116,7 +116,7 @@ public class MiscViews {
             }
         }
 
-        IntervalView<T> translated = Views.translate(imgPlusView.getImg(), newMin);
+        IntervalView<T> translated = Views.translate(imgPlusView, newMin);
 
         if (hasNonZeroMin) {
             ImgPlus<T> img = ImgPlus.wrap(ImgView.wrap(translated, imgPlusView.factory()), imgPlusView);

--- a/org.knime.knip.core/src/org/knime/knip/core/util/MiscViews.java
+++ b/org.knime.knip.core/src/org/knime/knip/core/util/MiscViews.java
@@ -80,21 +80,24 @@ import net.imglib2.view.Views;
  */
 public class MiscViews {
 
+    private MiscViews() {
+        // Utility class
+    }
+
     /**
      * removes dimensions of size 1 if any.
      *
-     * @param ret
-     * @return
+     * @param ret the cleaned image
      */
     public static <T extends Type<T>> ImgPlus<T> cleanImgPlus(final ImgPlus<T> ret) {
 
         final List<Integer> oneSizedDims = getOneSizeDims(ret);
-        if (oneSizedDims.size() == 0) {
+        if (oneSizedDims.isEmpty()) {
             return ret;
         }
 
         final ImgPlus<T> imgPlusView =
-                new ImgPlus<T>(ImgView.wrap(SubsetOperations.subsetview(ret.getImg(), ret.getImg()), ret.factory()));
+                new ImgPlus<>(ImgView.wrap(SubsetOperations.subsetview(ret.getImg(), ret.getImg()), ret.factory()));
         MetadataUtil.copyAndCleanImgPlusMetadata(ret, ret, imgPlusView);
 
         final long[] oldMin = Intervals.minAsLongArray(imgPlusView);
@@ -316,7 +319,8 @@ public class MiscViews {
             }
         }
 
-        int dim1 = 0, dim2 = 0;
+        int dim1 = 0;
+        int dim2 = 0;
 
         if (e.getPlaneDimIndex1() < target.numDimensions()) {
             dim1 = e.getPlaneDimIndex1();
@@ -347,10 +351,10 @@ public class MiscViews {
      * Calculate the delta axis which are missing in the smaller space. >
      * From the smallest index of axistype to the biggest
      */
-    private synchronized static TypedAxis[] getDeltaAxisTypes(final TypedSpace<? extends TypedAxis> sourceSpace,
+    private static synchronized TypedAxis[] getDeltaAxisTypes(final TypedSpace<? extends TypedAxis> sourceSpace,
                                                               final TypedSpace<? extends TypedAxis> targetSpace) {
 
-        final List<TypedAxis> delta = new ArrayList<TypedAxis>();
+        final List<TypedAxis> delta = new ArrayList<>();
         for (int d = 0; d < targetSpace.numDimensions(); d++) {
             final TypedAxis axis = targetSpace.axis(d);
             if (sourceSpace.dimensionIndex(axis.type()) == -1) {

--- a/org.knime.knip.core/src/org/knime/knip/core/util/MiscViews.java
+++ b/org.knime.knip.core/src/org/knime/knip/core/util/MiscViews.java
@@ -113,9 +113,15 @@ public class MiscViews {
             }
         }
 
-        return new ImgPlus<>(hasNonZeroMin
-                ? ImgView.wrap(Views.translate(imgPlusView.getImg(), newMin), imgPlusView.factory()) : imgPlusView,
-                imgPlusView);
+        IntervalView<T> translated = Views.translate(imgPlusView.getImg(), newMin);
+
+        if (hasNonZeroMin) {
+            ImgPlus<T> img = ImgPlus.wrap(ImgView.wrap(translated, imgPlusView.factory()), imgPlusView);
+            img.setSource(ret.getSource());
+            return img;
+        } else {
+            return ImgPlus.wrap(imgPlusView, imgPlusView);
+        }
     }
 
     /**


### PR DESCRIPTION
1. Fix loss of metadata when using the ``MiscViews.cleanImgPlus()`` method
    - Used in _Imgreader_ and _CleanDimensions_
2. Code cleanup in ``MiscViews``
3. removal of no longer needed code that sets previously lost metadata