### PR TITLE
Set faster defaults for Interactive Annotator

### DIFF
--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/annotation/create/OverlayAnnotatorNodeModel.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/annotation/create/OverlayAnnotatorNodeModel.java
@@ -100,11 +100,11 @@ public class OverlayAnnotatorNodeModel<T extends RealType<T> & NativeType<T>>
 	}
 
 	static SettingsModelString creatFactoryTypeSM() {
-		return new SettingsModelString("factory_type", ImgFactoryTypes.NTREE_IMG_FACTORY.toString());
+		return new SettingsModelString("factory_type", ImgFactoryTypes.ARRAY_IMG_FACTORY.toString());
 	}
 
 	static SettingsModelString createLabelingTypeSM() {
-		return new SettingsModelString("labeling_type", NativeTypes.SHORTTYPE.toString());
+		return new SettingsModelString("labeling_type", NativeTypes.BYTETYPE.toString());
 	}
 
 	private SettingsModelOverlayAnnotator m_annotationsSM = createAnnotatorSM();


### PR DESCRIPTION
- Default pixeltype is now "ByteType": In most cases users will not
    create more than 256 different labels by hand, if they do anyways the
    node will warn them and they can switch to an apropriate pixel type.
- Default Factory is now "ArrayImgFactory": This is usually the fastest
    factory, in most cases this should be enough.

Poor performance of the interactive annotator has been reported by an user [on the forum](https://tech.knime.org/forum/knime-image-processing/interactive-annotator-allows-only-for-a-limited-analysis-of-images#comment-47120).