### PR TITLE
Fix #388, Resizer forgets source

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/resizer/ResizerNodeFactory.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/proc/resizer/ResizerNodeFactory.java
@@ -368,13 +368,13 @@ public class ResizerNodeFactory<T extends RealType<T>> extends ValueToCellNodeFa
                             (calibration[i] * zeroMinFromCell.getImg().dimension(i)) / newDimensions[i])), i);
                 }
 
-                return m_imgCellFactory
-                        .createCell(MinimaUtils.getTranslatedImgPlus(fromCell, new ImgPlus<T>(
-                                resample(zeroMinFromCell,
-                                         EnumUtils.valueForName(m_extensionTypeModel.getStringValue(), ResizeStrategy
-                                                 .values()),
-                                         new FinalInterval(newDimensions), scaleFactors),
-                                metadata)));
+                ImgPlus<T> res = new ImgPlus<>(resample(zeroMinFromCell,
+                                                        EnumUtils.valueForName(m_extensionTypeModel.getStringValue(),
+                                                                               ResizeStrategy.values()),
+                                                        new FinalInterval(newDimensions), scaleFactors),
+                        metadata);
+                res.setSource(fromCell.getSource());
+                return m_imgCellFactory.createCell(MinimaUtils.getTranslatedImgPlus(fromCell, res));
             }
 
             /**


### PR DESCRIPTION
When creating a new ImgPlus the source property is to "". We want
to preserve it, so we need to set it again.