### PR TITLE
Fix feature sets

### DIFF
--- a/org.knime.knip.features/src/org/knime/knip/features/node/model/FeatureSetInfo.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/node/model/FeatureSetInfo.java
@@ -133,6 +133,8 @@ public class FeatureSetInfo {
 
 	private void validateAndInitialize(final Module module) {
 
+		module.setResolved("ps", true);
+		module.setResolved("cs", true);
 		// resolve default input and output
 		module.setResolved("in", true);
 		module.setResolved("out", true);

--- a/org.knime.knip.features/src/org/knime/knip/features/node/model/SettingsModelFeatureSet.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/node/model/SettingsModelFeatureSet.java
@@ -50,6 +50,8 @@ package org.knime.knip.features.node.model;
 
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -57,15 +59,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
 import net.imglib2.util.Pair;
 
+import org.eclipse.swt.widgets.Display;
 import org.knime.core.node.InvalidSettingsException;
 import org.knime.core.node.NodeSettingsRO;
 import org.knime.core.node.NodeSettingsWO;
 import org.knime.core.node.NotConfigurableException;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.core.node.port.PortObjectSpec;
+import org.knime.knip.core.KNIPGateway;
+import org.knime.knip.core.KNIPLogService;
 import org.knime.knip.features.sets.FeatureSet;
+import org.knime.workbench.core.KNIMEErrorDialog;
+import org.scijava.log.LogService;
 
 public class SettingsModelFeatureSet extends SettingsModel {
 
@@ -82,6 +94,13 @@ public class SettingsModelFeatureSet extends SettingsModel {
 
 	private final String m_configName;
 	private List<FeatureSetInfo> m_featureSets;
+	
+	private final LogService logger = KNIPGateway.log();
+	
+	// Update-Dialog should only pop up once.
+	boolean infoShownRugosity = false;
+	boolean infoShownAngleFerets = true;
+	boolean infoShownDiameterFerets = true;
 
 	/**
 	 * Creates a new object holding an integer value.
@@ -188,11 +207,33 @@ public class SettingsModelFeatureSet extends SettingsModel {
 				try {
 					fieldValue = loadObject(featureSetSettings, FIELD_VALUE + j,
 							featureSetClass.getDeclaredField(fieldName).getType());
+					fieldNamesAndValues.put(fieldName, fieldValue);
 				} catch (NoSuchFieldException | SecurityException e) {
-					throw new InvalidSettingsException("Couldn't load field value", e);
+					if (e.getMessage().equals("isRugosityActive")) {
+						if (!infoShownRugosity) {
+							infoShownRugosity = true;
+							logger.warn("Rugosity feature was removed, because it was a duplicate of convexity.");
+						}
+					} else if (e.getMessage().equals("isFeretsAngleActive")) {
+						if (!infoShownAngleFerets) {
+							infoShownAngleFerets = true;
+							logger.warn("Ferets Angle feature was replaced by Min-, Max Ferets Angle.\n"
+									+ "The new features were added and activated.");
+						}
+						fieldNamesAndValues.put("isMinimumFeretsAngleActive", true);
+						fieldNamesAndValues.put("isMaximumFeretsAngleActive", true);
+					} else if (e.getMessage().equals("isFeretsDiameterActive")) {
+						if (!infoShownDiameterFerets) {
+							infoShownDiameterFerets = true;
+							logger.warn("Ferets Diameter feature was replaced by Min-, Max Ferets Diameter.\n"
+									+ "The new features were added and activated.");
+						}
+						fieldNamesAndValues.put("isMinimumFeretsDiameterActive", true);
+						fieldNamesAndValues.put("isMaximumFeretsDiameterActive", true);
+					} else {
+						throw new InvalidSettingsException("Couldn't load field value", e);
+					}
 				}
-
-				fieldNamesAndValues.put(fieldName, fieldValue);
 			}
 
 			featureSets.add(new FeatureSetInfo(featureSetClass, fieldNamesAndValues));
@@ -234,11 +275,34 @@ public class SettingsModelFeatureSet extends SettingsModel {
 				try {
 					fieldValue = loadObject(featureSetSettings, FIELD_VALUE + j,
 							featureSetClass.getDeclaredField(fieldName).getType());
+					fieldNamesAndValues.put(fieldName, fieldValue);
 				} catch (NoSuchFieldException | SecurityException e) {
-					throw new InvalidSettingsException("Couldn't load field value", e);
+					if (e.getMessage().equals("isRugosityActive")) {
+						if (!infoShownRugosity) {
+							infoShownRugosity = true;
+							logger.warn("Rugosity feature was removed, because it was a duplicate of convexity.");
+						}
+					} else if (e.getMessage().equals("isFeretsAngleActive")) {
+						if (!infoShownAngleFerets) {
+							infoShownAngleFerets = true;
+							logger.warn("Ferets Angle feature was replaced by Min-, Max Ferets Angle.\n"
+									+ "The new features were added and activated.");
+						}
+						fieldNamesAndValues.put("isMinimumFeretsAngleActive", true);
+						fieldNamesAndValues.put("isMaximumFeretsAngleActive", true);
+					} else if (e.getMessage().equals("isFeretsDiameterActive")) {
+						if (!infoShownDiameterFerets) {
+							infoShownDiameterFerets = true;
+							logger.warn("Ferets Diameter feature was replaced by Min-, Max Ferets Diameter.\n"
+									+ "The new features were added and activated.");
+						}
+						fieldNamesAndValues.put("isMinimumFeretsDiameterActive", true);
+						fieldNamesAndValues.put("isMaximumFeretsDiameterActive", true);
+					} else {
+						throw new InvalidSettingsException("Couldn't load field value", e);
+					}
 				}
 
-				fieldNamesAndValues.put(fieldName, fieldValue);
 			}
 
 			featureSets.add(new FeatureSetInfo(featureSetClass, fieldNamesAndValues));

--- a/org.knime.knip.features/src/org/knime/knip/features/sets/AbstractOpRefFeatureSet.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/sets/AbstractOpRefFeatureSet.java
@@ -139,7 +139,7 @@ public abstract class AbstractOpRefFeatureSet<I, O extends RealType<O>> extends 
 						args[i++] = self.getInput(param);
 					}
 
-					Class<? extends Op> type = (Class<? extends Op>) Class.forName((String) item.get(ATTR_TYPE));
+					Class<? extends Op> type = (Class<? extends Op>) Class.forName(item.get(ATTR_TYPE));
 					final OpRef ref = new OpRef(null, Arrays.asList(type), null, args);
 
 					namedFeatureMap.put(new NamedFeature(ref, item.getLabel()),

--- a/org.knime.knip.features/src/org/knime/knip/features/sets/Geometric2DFeatureSet.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/sets/Geometric2DFeatureSet.java
@@ -96,13 +96,21 @@ public class Geometric2DFeatureSet<L, O extends RealType<O>> extends AbstractOpR
 			@Attr(name = ATTR_TYPE, value = PKG + "MainElongation") })
 	private boolean isMainElongationActive = true;
 
-	@Parameter(required = false, label = "Ferets Angle", attrs = { @Attr(name = ATTR_FEATURE),
-			@Attr(name = ATTR_TYPE, value = PKG + "FeretsAngle") })
-	private boolean isFeretsAngleActive = true;
+	@Parameter(required = false, label = "Minimum Ferets Angle", attrs = { @Attr(name = ATTR_FEATURE),
+			@Attr(name = ATTR_TYPE, value = PKG + "MinimumFeretsAngle") })
+	private boolean isMinimumFeretsAngleActive = true;
 
-	@Parameter(required = false, label = "Ferets Diameter", attrs = { @Attr(name = ATTR_FEATURE),
-			@Attr(name = ATTR_TYPE, value = PKG + "FeretsDiameter") })
-	private boolean isFeretsDiameterActive = true;
+	@Parameter(required = false, label = "Minimum Ferets Diameter", attrs = { @Attr(name = ATTR_FEATURE),
+			@Attr(name = ATTR_TYPE, value = PKG + "MinimumFeretsDiameter") })
+	private boolean isMinimumFeretsDiameterActive = true;
+	
+	@Parameter(required = false, label = "Maximum Ferets Angle", attrs = { @Attr(name = ATTR_FEATURE),
+			@Attr(name = ATTR_TYPE, value = PKG + "MaximumFeretsAngle") })
+	private boolean isMaximumFeretsAngleActive = true;
+
+	@Parameter(required = false, label = "Maximum Ferets Diameter", attrs = { @Attr(name = ATTR_FEATURE),
+			@Attr(name = ATTR_TYPE, value = PKG + "MaximumFeretsDiameter") })
+	private boolean isMaximumFeretsDiameterActive = true;
 
 	@Parameter(required = false, label = "Major Axis", attrs = { @Attr(name = ATTR_FEATURE),
 			@Attr(name = ATTR_TYPE, value = PKG + "MajorAxis") })

--- a/org.knime.knip.features/src/org/knime/knip/features/sets/Geometric2DFeatureSet.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/sets/Geometric2DFeatureSet.java
@@ -124,10 +124,6 @@ public class Geometric2DFeatureSet<L, O extends RealType<O>> extends AbstractOpR
 			@Attr(name = ATTR_TYPE, value = PKG + "Roundness") })
 	private boolean isRoundnessActive = true;
 
-	@Parameter(required = false, label = "Rugosity", attrs = { @Attr(name = ATTR_FEATURE),
-			@Attr(name = ATTR_TYPE, value = PKG + "Rugosity") })
-	private boolean isRugosityActive = true;
-
 	@Parameter(required = false, label = "Solidity", attrs = { @Attr(name = ATTR_FEATURE),
 			@Attr(name = ATTR_TYPE, value = PKG + "Solidity") })
 	private boolean isSolidityActive = true;

--- a/org.knime.knip.features/src/org/knime/knip/features/sets/Geometric3DFeatureSet.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/sets/Geometric3DFeatureSet.java
@@ -93,11 +93,11 @@ public class Geometric3DFeatureSet<L, O extends RealType<O>> extends AbstractOpR
 	private boolean isBoundarySizeActive = true;
 
 	@Parameter(required = false, label = "Surface Area (in pixel units)", attrs = { @Attr(name = ATTR_FEATURE),
-			@Attr(name = ATTR_TYPE, value = PKG + "BoundaryPixelCount") })
+			@Attr(name = ATTR_TYPE, value = PKG + "VerticesCount") })
 	private boolean isBoundaryPixelCountActive = true;
 
 	@Parameter(required = false, label = "Surface Area of Convex Hull (in pixel units)", attrs = {
-			@Attr(name = ATTR_FEATURE), @Attr(name = ATTR_TYPE, value = PKG + "BoundaryPixelCountConvexHull") })
+			@Attr(name = ATTR_FEATURE), @Attr(name = ATTR_TYPE, value = PKG + "VerticesCountConvexHull") })
 	private boolean isBoundaryPixelCountConvexHullMeshActive = true;
 
 	@Parameter(required = false, label = "Compactness", attrs = { @Attr(name = ATTR_FEATURE),
@@ -107,10 +107,6 @@ public class Geometric3DFeatureSet<L, O extends RealType<O>> extends AbstractOpR
 	@Parameter(required = false, label = "Convexity", attrs = { @Attr(name = ATTR_FEATURE),
 			@Attr(name = ATTR_TYPE, value = PKG + "Convexity") })
 	private boolean isConvexityActive = true;
-
-	@Parameter(required = false, label = "Rugosity", attrs = { @Attr(name = ATTR_FEATURE),
-			@Attr(name = ATTR_TYPE, value = PKG + "Rugosity") })
-	private boolean isRugosityActive = true;
 
 	@Parameter(required = false, label = "Solidity", attrs = { @Attr(name = ATTR_FEATURE),
 			@Attr(name = ATTR_TYPE, value = PKG + "Solidity") })


### PR DESCRIPTION
@dietzc I had to resolve cs like you resolved ps.

If old features were selected they get replaced by the new ones and a warn-message is written to the console. 

If only the name of a feature changed no message is written.

The new features are selected if the old features were selected. 

I updated the old test-workflow (some feature numbers have changed, due to bug fixes) and put it on the server. 
New name: KNIME_testing_FeatureCalculator_updated