### PR TITLE
Improve segment filter dialog

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentFilterSelection.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/node/dialog/DialogComponentFilterSelection.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -93,6 +94,12 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
     private final List<JTextField> m_textFields;
 
     private final JPanel m_textFieldsPanel;
+
+    private final JCheckBox m_caseSensitiveMatch;
+
+    private final JCheckBox m_containsWildCards;
+
+    private final JCheckBox m_regularExpression;
 
     private GridBagConstraints m_textFieldsGBC;
 
@@ -130,6 +137,36 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
 
         m_operatorBox = new JComboBox(RulebasedLabelFilter.Operator.values());
 
+        m_caseSensitiveMatch = new JCheckBox("Case Sensitive Match");
+        m_caseSensitiveMatch.setEnabled(false);
+
+        m_containsWildCards = new JCheckBox("Contains Wild Cards");
+        m_containsWildCards.setEnabled(false);
+        m_containsWildCards.addChangeListener(new ChangeListener() {
+
+            @Override
+            public void stateChanged(final ChangeEvent e) {
+                if ((e.getSource() == m_containsWildCards) && m_containsWildCards.isSelected()) {
+                    m_regularExpression.setSelected(false);
+                }
+            }
+        });
+
+        m_regularExpression = new JCheckBox("Regular Expression");
+        m_regularExpression.setEnabled(false);
+        m_regularExpression.addChangeListener(new ChangeListener() {
+
+            @Override
+            public void stateChanged(final ChangeEvent e) {
+                if ((e.getSource() == m_regularExpression) && m_regularExpression.isSelected()) {
+                    m_containsWildCards.setSelected(false);
+                }
+            }
+        });
+
+        final JPanel ruleConfigurationPanel = new JPanel(new GridBagLayout());
+
+
         getComponentPanel().setLayout(new GridBagLayout());
 
         final GridBagConstraints dialogGBC = new GridBagConstraints();
@@ -138,8 +175,19 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
         dialogGBC.weighty = 1;
         dialogGBC.gridx = 0;
         dialogGBC.gridy = 0;
-        dialogGBC.insets = new Insets(2, 2, 2, 2);
         dialogGBC.anchor = GridBagConstraints.NORTH;
+
+        ruleConfigurationPanel.add(m_caseSensitiveMatch, dialogGBC);
+        dialogGBC.gridx++;
+        ruleConfigurationPanel.add(m_regularExpression, dialogGBC);
+        dialogGBC.gridx++;
+        ruleConfigurationPanel.add(m_containsWildCards, dialogGBC);
+
+        dialogGBC.gridx = 0;
+        dialogGBC.insets = new Insets(2, 2, 2, 2);
+
+        getComponentPanel().add(ruleConfigurationPanel, dialogGBC);
+        dialogGBC.gridy++;
 
         getComponentPanel().add(m_textFieldsPanel, dialogGBC);
         dialogGBC.fill = GridBagConstraints.NONE;
@@ -197,6 +245,12 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
                 m_textFieldsPanel.remove(removeButton.getParent());
                 getComponentPanel().updateUI();
                 m_textFieldsGBC.gridy--;
+
+                if (m_textFieldsGBC.gridy == 0) {
+                    m_caseSensitiveMatch.setEnabled(false);
+                    m_containsWildCards.setEnabled(false);
+                    m_regularExpression.setEnabled(false);
+                }
             }
         });
 
@@ -207,6 +261,10 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
         m_removeButtons.add(removeButton);
         m_textFieldsPanel.add(oneFieldRow, m_textFieldsGBC);
         m_textFieldsGBC.gridy++;
+
+        m_caseSensitiveMatch.setEnabled(true);
+        m_containsWildCards.setEnabled(true);
+        m_regularExpression.setEnabled(true);
 
         getComponentPanel().updateUI();
 
@@ -259,6 +317,10 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
         m_operatorBox.setSelectedItem(model.getOperator());
         getComponentPanel().updateUI();
         setEnabledComponents(getModel().isEnabled());
+
+        m_caseSensitiveMatch.setSelected(model.getCaseSensitiveMatch());
+        m_containsWildCards.setSelected(model.getContainsWildCards());
+        m_regularExpression.setSelected(model.getRegularExpression());
     }
 
     private void updateModel() {
@@ -273,6 +335,9 @@ public class DialogComponentFilterSelection<L extends Comparable<L>> extends Dia
         model.setRules(tmp);
         model.setOperator((RulebasedLabelFilter.Operator)m_operatorBox.getSelectedItem());
 
+        model.setCaseSensitiveMatch(m_caseSensitiveMatch.isSelected());
+        model.setContainsWildCards(m_containsWildCards.isSelected());
+        model.setRegularExpression(m_regularExpression.isSelected());
     }
 
     @Override

--- a/org.knime.knip.core/META-INF/MANIFEST.MF
+++ b/org.knime.knip.core/META-INF/MANIFEST.MF
@@ -96,3 +96,4 @@ Export-Package: org.knime.knip.core,
  org.knime.knip.core.util.waitingindicator,
  org.knime.knip.core.util.waitingindicator.libs,
  org.knime.knip.io.nodes.annotation.deprecated
+Import-Package: org.knime.base.util

--- a/org.knime.knip.core/src/org/knime/knip/core/ui/imgviewer/panels/LabelFilterPanel.java
+++ b/org.knime.knip.core/src/org/knime/knip/core/ui/imgviewer/panels/LabelFilterPanel.java
@@ -361,7 +361,7 @@ public class LabelFilterPanel<L> extends ViewerComponent {
             final Set<String> allLabels = new HashSet<String>();
             m_ruleFilter.clear();
             for (int i = 0; i < m_textFields.size(); i++) {
-                m_ruleFilter.addRules(RulebasedLabelFilter.formatRegExp(m_textFields.get(i).getText()));
+                m_ruleFilter.addRules(RulebasedLabelFilter.compileRegularExpression(false, false, true, m_textFields.get(i).getText()));
             }
             m_activeLabels.clear();
 
@@ -470,7 +470,7 @@ public class LabelFilterPanel<L> extends ViewerComponent {
         m_ruleFilter.readExternal(in);
 
         for (int s = 0; s < m_ruleFilter.getRules().size(); s++) {
-            addTextField(m_ruleFilter.getRules().get(s));
+            addTextField(m_ruleFilter.getRules().get(s).pattern());
         }
     }
 


### PR DESCRIPTION
Add the logic of the KNIME Row Filter node to the Segment Filter Dialog. The user can now choose between simple string matching, regex matching, wildcard matching and also make use of case sensitive matching.

This is how the dialog looks now:
![image](https://cloud.githubusercontent.com/assets/5450869/24202326/05037202-0f13-11e7-9eaf-81d7b9fb7d45.png)

This should resolve issue https://github.com/knime-ip/knip/issues/460.

The dialog is still backwards compatible. I identified the old settings as case sensitive wild card matching. Can someone ( @gab1one, @dietzc, @hornm  ) double-check? 

Note: This also "affects" ([implementation changed](https://github.com/knime-ip/knip/blob/improveSegmentFilterDialog/org.knime.knip.core/src/org/knime/knip/core/ui/imgviewer/panels/LabelFilterPanel.java#L364), behaviour is still the same) label filtering in all views. 