### PR TITLE
Fix Loops and 'Don't Save' exception at workflow save

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/util/slicelooper/SliceIteratorLoopEndNodeModel.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/util/slicelooper/SliceIteratorLoopEndNodeModel.java
@@ -350,6 +350,7 @@ public class SliceIteratorLoopEndNodeModel<T extends RealType<T> & NativeType<T>
         m_cells = null;
         m_iterator = null;
         m_resultContainer = null;
+        m_data = null;
         m_currentRow = null;
         m_imgPlusCellFactory = null;
         m_labelingCellFactory = null;

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/util/slicelooper/SliceIteratorLoopStartNodeModel.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/util/slicelooper/SliceIteratorLoopStartNodeModel.java
@@ -442,6 +442,7 @@ public class SliceIteratorLoopStartNodeModel<T extends RealType<T> & NativeType<
         isRowTerminated = false;
         areAllRowsTerminated = false;
         m_iterator = null;
+        m_data = null;
         m_imgPlusCellFactory = null;
         m_labelingCellFactory = null;
         m_allIntervals = null;

--- a/org.knime.knip.base/src/org/knime/knip/base/nodes/util/tilelooper/TileIteratorLoopStartNodeModel.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/nodes/util/tilelooper/TileIteratorLoopStartNodeModel.java
@@ -137,8 +137,6 @@ public class TileIteratorLoopStartNodeModel<T extends RealType<T>> extends NodeM
 
     private long m_iteration;
 
-    private BufferedDataTable m_table;
-
     private CloseableRowIterator m_iterator;
 
     private ImgPlusCellFactory m_cellFactory;
@@ -179,7 +177,6 @@ public class TileIteratorLoopStartNodeModel<T extends RealType<T>> extends NodeM
 
         // Do some preperation
         if (m_iteration == 0) {
-            m_table = table;
             m_iterator = table.iterator();
         }
         m_cellFactory = new ImgPlusCellFactory(exec);
@@ -361,7 +358,7 @@ public class TileIteratorLoopStartNodeModel<T extends RealType<T>> extends NodeM
             m_iterator.close();
         }
         m_iterator = null;
-        m_table = null;
+        m_dataTable = null;
         m_cellFactory = null;
     }
 


### PR DESCRIPTION
The Exception occurred because the nodes didn't reset the internal tables.

(It was in both loops because I created the Tile Loop with the Slice Loop as a reference)