### PR TITLE
 KNIPGuavaCacheService: Switch to String based cache

### DIFF
--- a/org.knime.knip.base/src/org/knime/knip/base/data/img/ImgPlusCell.java
+++ b/org.knime.knip.base/src/org/knime/knip/base/data/img/ImgPlusCell.java
@@ -107,6 +107,8 @@ import net.imglib2.view.Views;
 public class ImgPlusCell<T extends RealType<T>> extends FileStoreCell
         implements ImgPlusValue<T>, StringValue, IntervalValue {
 
+    private static final String IMG_PLUS_CELL_KEY = "IP";
+
     /**
      * Type
      *
@@ -122,7 +124,7 @@ public class ImgPlusCell<T extends RealType<T>> extends FileStoreCell
     /**
      * UID
      */
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private FileStoreCellMetadata m_fileMetadata;
 
@@ -170,7 +172,7 @@ public class ImgPlusCell<T extends RealType<T>> extends FileStoreCell
 
         m_fileMetadata = new FileStoreCellMetadata(-1, false, null);
 
-        CACHE.put(this, this);
+        CACHE.put(this.stringHashCode(), this);
     }
 
     /**
@@ -241,7 +243,14 @@ public class ImgPlusCell<T extends RealType<T>> extends FileStoreCell
      */
     @Override
     protected boolean equalsDataCell(final DataCell dc) {
-        return dc.hashCode() == hashCode();
+        if (dc instanceof ImgPlusCell) {
+            ImgPlusCell dc2 = (ImgPlusCell)dc;
+            if (dc2.getFileStore().getFile().equals(this.getFileStore().getFile())
+                    && dc2.m_fileMetadata.getOffset() == this.m_fileMetadata.getOffset()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -461,7 +470,7 @@ public class ImgPlusCell<T extends RealType<T>> extends FileStoreCell
                         tmp = new ImgPlusCellMetadata(tmp.getMetadata(), tmp.getSize(), tmp.getMinimum(),
                                 tmp.getDimensions(), tmp.getPixelType(), createThumbnail(height / fullHeight)));
                 // update cached object
-                CACHE.put(this, this);
+                CACHE.put(this.stringHashCode(), this);
             }
             return tmp.getThumbnail();
         }
@@ -482,7 +491,11 @@ public class ImgPlusCell<T extends RealType<T>> extends FileStoreCell
      */
     @Override
     public int hashCode() {
-        return (int)(getFileStore().getFile().hashCode() + (31 * m_fileMetadata.getOffset()));
+        return stringHashCode().hashCode();
+    }
+
+    private String stringHashCode() {
+        return IMG_PLUS_CELL_KEY + getFileStore().getFile().getName() + m_fileMetadata.getOffset();
     }
 
     /**

--- a/org.knime.knip.core/src/org/knime/knip/core/ui/imgviewer/panels/providers/AWTImageProvider.java
+++ b/org.knime.knip.core/src/org/knime/knip/core/ui/imgviewer/panels/providers/AWTImageProvider.java
@@ -92,6 +92,8 @@ public class AWTImageProvider extends HiddenViewerComponent {
 
     private static final NodeLogger LOGGER = NodeLogger.getLogger(AWTImageProvider.class);
 
+    private static final String AWT_IMAGE_PROVIDE_KEY = "AP";
+
     /**
      * Converts DoubleType to FloatType and preserves other types. This can be used to ensure that images (after calling
      * the method) are FloatType or smaller and thus can be normalized. However type safety is broken!
@@ -158,13 +160,13 @@ public class AWTImageProvider extends HiddenViewerComponent {
         Image awtImage = null;
         if (m_isCachingActive) {
 
-            final int hash = (31 + m_renderUnit.generateHashCode());
-            awtImage = (Image)KNIPGateway.cache().get(hash);
+            final String hashKey = AWT_IMAGE_PROVIDE_KEY + m_renderUnit.generateHashCode();
+            awtImage = (Image)KNIPGateway.cache().get(hashKey);
 
             if (awtImage == null) {
                 awtImage = m_renderUnit.createImage();
 
-                KNIPGateway.cache().put(hash, awtImage);
+                KNIPGateway.cache().put(hashKey, awtImage);
                 LOGGER.info("Caching Image ...");
             } else {
                 LOGGER.info("Image from Cache ...");

--- a/org.knime.knip.features/src/org/knime/knip/features/sets/optimizedfeatures/KNIPCachedOpEnvironment.java
+++ b/org.knime.knip.features/src/org/knime/knip/features/sets/optimizedfeatures/KNIPCachedOpEnvironment.java
@@ -59,8 +59,6 @@ import net.imagej.ops.special.hybrid.UnaryHybridCF;
  */
 public class KNIPCachedOpEnvironment extends CustomOpEnvironment {
 
-	@Parameter
-	private CacheService cs;
 	private Collection<Class<?>> ignored;
 
 	public KNIPCachedOpEnvironment(final OpEnvironment parent, final Collection<? extends OpInfo> prioritizedInfos,

--- a/org.knime.knip.io/src/org/knime/knip/io/ImgRefCell.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/ImgRefCell.java
@@ -185,6 +185,8 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 	 */
 	public static final DataType TYPE = DataType.getType(ImgRefCell.class);
 
+	private static final String IMG_REF_KEY = "IR";
+
 	/**
 	 * Returns the factory to read/write DataCells of this class from/to a
 	 * DataInput/DataOutput. This method is called via reflection.
@@ -264,10 +266,10 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 			return m_originalDims;
 		}
 		try {
-			long[] dim = (long[]) CACHE.get(m_imgRef + DIM_SUFFIX);
+			long[] dim = (long[]) CACHE.get(IMG_REF_KEY + m_imgRef + DIM_SUFFIX);
 			if (dim == null) {
 				dim = ImgSourcePool.getImgSource(m_sourceID).getDimensions(m_imgRef, 0);
-				CACHE.put(m_imgRef + DIM_SUFFIX, dim);
+				CACHE.put(IMG_REF_KEY + m_imgRef + DIM_SUFFIX, dim);
 			}
 			return dim;
 		} catch (final Exception e) {
@@ -291,10 +293,10 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 	private Img<T> getImg() {
 		final long[] dims = getDimensions();
 		try {
-			Img<T> img = (Img<T>) CACHE.get(m_imgRef + IMG_SUFFIX);
+			Img<T> img = (Img<T>) CACHE.get(IMG_REF_KEY + m_imgRef + IMG_SUFFIX);
 			if (img == null) {
 				img = (Img<T>) ImgSourcePool.getImgSource(m_sourceID).getImg(m_imgRef, 0);
-				CACHE.put(m_imgRef + IMG_SUFFIX, img);
+				CACHE.put(IMG_REF_KEY + m_imgRef + IMG_SUFFIX, img);
 			}
 			return img;
 		} catch (final Exception e) {
@@ -321,7 +323,7 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 	 */
 	@Override
 	public ImgPlus<T> getImgPlus() {
-		return new ImgPlus<T>(getImg(), getMetadata());
+		return new ImgPlus<>(getImg(), getMetadata());
 	}
 
 	/**
@@ -342,10 +344,10 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 
 		List<CalibratedAxis> tmpAxes;
 		try {
-			tmpAxes = (List<CalibratedAxis>) CACHE.get(m_imgRef + AXES_SUFFIX);
+			tmpAxes = (List<CalibratedAxis>) CACHE.get(IMG_REF_KEY + m_imgRef + AXES_SUFFIX);
 			if (tmpAxes == null) {
 				tmpAxes = ImgSourcePool.getImgSource(m_sourceID).getAxes(m_imgRef, 0);
-				CACHE.put(m_imgRef + AXES_SUFFIX, tmpAxes);
+				CACHE.put(IMG_REF_KEY + m_imgRef + AXES_SUFFIX, tmpAxes);
 			}
 		} catch (final Exception e) {
 			noAccessWarning(e);
@@ -516,15 +518,7 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 	 */
 	@Override
 	public String getStringValue() {
-		final ImgSource fac = (ImgSource) CACHE.get(m_sourceID);
 		String facDesc = "unknown source";
-		if (fac != null) {
-			try {
-				facDesc = fac.getSource(m_sourceID);
-			} catch (final Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
 		return m_imgRef + " (" + facDesc + ")";
 	}
 

--- a/org.knime.knip.io/src/org/knime/knip/io/ImgRefCell.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/ImgRefCell.java
@@ -331,7 +331,7 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 	 */
 	@Override
 	public ImgPlus<T> getImgPlusCopy() {
-		return new ImgPlus<T>(getImgCopy(), getMetadata());
+		return new ImgPlus<>(getImgCopy(), getMetadata());
 	}
 
 	/**
@@ -351,14 +351,14 @@ public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataC
 			}
 		} catch (final Exception e) {
 			noAccessWarning(e);
-			tmpAxes = new ArrayList<CalibratedAxis>();
+			tmpAxes = new ArrayList<>();
 			for (int i = 0; i < getDimensions().length; i++) {
 				tmpAxes.add(new DefaultLinearAxis(Axes.get("Unknown " + i)));
 			}
 		}
 
 		// setting everything to metadata
-		final List<CalibratedAxis> axes = new ArrayList<CalibratedAxis>(tmpAxes);
+		final List<CalibratedAxis> axes = new ArrayList<>(tmpAxes);
 
 		// TODO: Can be replaced by FinalMetadata?!
 		return new ImgPlusMetadata() {

--- a/org.knime.knip.io/src/org/knime/knip/io/ImgRefCell.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/ImgRefCell.java
@@ -105,6 +105,7 @@ import net.imglib2.type.numeric.integer.ByteType;
  *         Zinsmaier</a>
  */
 @SuppressWarnings("serial")
+@Deprecated
 public class ImgRefCell<T extends RealType<T> & NativeType<T>> extends BlobDataCell
 		implements ImgRefValue, ImgPlusValue<T>, StringValue {
 

--- a/org.knime.knip.io/src/org/knime/knip/io/ImgRefValue.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/ImgRefValue.java
@@ -68,6 +68,7 @@ import org.knime.knip.base.renderer.ThumbnailRenderer;
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael
  *         Zinsmaier</a>
  */
+@Deprecated
 public interface ImgRefValue extends DataValue {
 
     /** Gathers meta information to this type. */

--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/IONodeSetFactory.java
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/IONodeSetFactory.java
@@ -122,7 +122,6 @@ public class IONodeSetFactory implements NodeSetFactory {
 		// m_nodeFactories.put(ImgReaderNodeFactory.class.getCanonicalName(),
 		// "/community/knip/io");
 		m_nodeFactories.put(ImgWriter2NodeFactory.class.getCanonicalName(), "/community/knip/io");
-		m_nodeFactories.put(ImageFileRefNodeFactory.class.getCanonicalName(), "/community/knip/io/other");
 		m_nodeFactories.put(ImgImporterNodeFactory.class.getCanonicalName(), "/community/knip/io/other");
 		m_nodeFactories.put(OverlayAnnotatorNodeFactory.class.getCanonicalName(), "/community/knip/labeling");
 		m_nodeFactories.put(ImgReader2NodeFactory.class.getCanonicalName(), "/community/knip/io");

--- a/org.knime.knip.io/src/org/knime/knip/io/nodes/fileref/ImageFileRefNodeFactory.xml
+++ b/org.knime.knip.io/src/org/knime/knip/io/nodes/fileref/ImageFileRefNodeFactory.xml
@@ -5,7 +5,7 @@
 	Contributors: IBM Corporation - initial API and implementation -->
 
 <!DOCTYPE knimeNode PUBLIC "-//UNIKN//DTD KNIME Node 2.0//EN" "http://www.knime.org/Node.dtd">
-<knimeNode icon="imagefileref.png" type="Source">
+<knimeNode icon="imagefileref.png" type="Source" deprecated="true">
 	<name>Image File Linker</name>
 	<shortDescription>Creates references to image files.</shortDescription>
 


### PR DESCRIPTION
This allows us to prevent collisions more easily, the key for each cache entry is
based on the filestore location + the offset within it, which is
globally unique