### PR TITLE
Add a new Externalizer for ImageMetaData, that de-duplicates ColorTables

### DIFF
--- a/org.knime.knip.core/src/org/knime/knip/core/io/externalization/ExternalizerManager.java
+++ b/org.knime.knip.core/src/org/knime/knip/core/io/externalization/ExternalizerManager.java
@@ -69,6 +69,7 @@ import org.knime.knip.core.io.externalization.externalizers.DefaultLinearSpaceEx
 import org.knime.knip.core.io.externalization.externalizers.ImageMetadataExt0;
 import org.knime.knip.core.io.externalization.externalizers.ImageMetadataExt1;
 import org.knime.knip.core.io.externalization.externalizers.ImageMetadataExt2;
+import org.knime.knip.core.io.externalization.externalizers.ImageMetadataExt3;
 import org.knime.knip.core.io.externalization.externalizers.ImgExt0;
 import org.knime.knip.core.io.externalization.externalizers.ImgExt1;
 import org.knime.knip.core.io.externalization.externalizers.ImgExt2;
@@ -154,6 +155,7 @@ public final class ExternalizerManager {
         registerExternalizer(new ImageMetadataExt0());
         registerExternalizer(new ImageMetadataExt1());
         registerExternalizer(new ImageMetadataExt2());
+        registerExternalizer(new ImageMetadataExt3());
 
         registerExternalizer(new DefaultLinearSpaceExt0());
 


### PR DESCRIPTION
Fixes some of the issues of #501.
## Before
![selection_010](https://user-images.githubusercontent.com/1938154/42651535-f3acc114-860f-11e8-8d37-f846c4a433ad.png)
## After
![selection_009](https://user-images.githubusercontent.com/1938154/42651547-fda92446-860f-11e8-999f-0bb246a50a57.png)
