### PR TITLE
AP-21672: fix registration of LogService implementation

### DIFF
--- a/org.knime.knip.core/src/META-INF/json/org.scijava.plugin.Plugin
+++ b/org.knime.knip.core/src/META-INF/json/org.scijava.plugin.Plugin
@@ -1,0 +1,1 @@
+ {"class":"org.knime.knip.core.KNIPLogService","values":{"type":"org.scijava.log.LogService"}}


### PR DESCRIPTION
Details are in the (private) KNIME AP ticket tracker (https://knime-com.atlassian.net/browse/AP-21672)

This fix registers the existing 'Plugin' definition with the class discovery, which was largely inspired from looking at other Service implementation and debugging code. There are more definitions, such as `DefaultLabelingService`, `DefaultMemoryService`, `KNIPThreadService`, which are probably also not properly registered/discovered. Given my limited knowledge about KNIP and scijava I refrain from changing it blindly.

This fix here fixes the concrete issue. On the AP side, starting with 5.2.6, there will be better error handling in case a 3rd party extension (like this one) causes trouble.

```
Full stack trace:
!MESSAGE An error occurred while automatically activating bundle org.knime.jsnippets (1649). !STACK 0
org.osgi.framework.BundleException: Exception in org.knime.base.node.jsnippet.JavaSnippetActivator.start() of bundle org.knime.jsnippets.
	at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:839)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:767)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.startWorker0(EquinoxBundle.java:1032)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.startWorker(EquinoxBundle.java:371)
	at org.eclipse.osgi.container.Module.doStart(Module.java:605)
	at org.eclipse.osgi.container.Module.start(Module.java:468)
	at org.eclipse.osgi.framework.util.SecureAction.start(SecureAction.java:513)
	at org.eclipse.osgi.internal.hooks.EclipseLazyStarter.postFindLocalClass(EclipseLazyStarter.java:117)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findLocalClass(ClasspathManager.java:570)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.findLocalClass(ModuleClassLoader.java:335)
	at org.eclipse.osgi.internal.loader.BundleLoader.findLocalClass(BundleLoader.java:397)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:500)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:416)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:168)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at org.knime.bigdata.spark.node.StandardSparkNodeFactoryProvider.<init>(StandardSparkNodeFactoryProvider.java:215)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.eclipse.core.internal.registry.osgi.RegistryStrategyOSGI.createExecutableExtension(RegistryStrategyOSGI.java:204)
	at org.eclipse.core.internal.registry.ExtensionRegistry.createExecutableExtension(ExtensionRegistry.java:920)
	at org.eclipse.core.internal.registry.ConfigurationElement.createExecutableExtension(ConfigurationElement.java:246)
	at org.eclipse.core.internal.registry.ConfigurationElementHandle.createExecutableExtension(ConfigurationElementHandle.java:63)
	at org.knime.bigdata.spark.core.version.SparkProviderRegistry.registerExtensions(SparkProviderRegistry.java:74)
	at org.knime.bigdata.spark.core.version.SparkProviderRegistry.registerExtensions(SparkProviderRegistry.java:46)
	at org.knime.bigdata.spark.core.node.SparkNodeFactoryRegistry.getInstance(SparkNodeFactoryRegistry.java:62)
	at org.knime.bigdata.spark.core.node.SparkNodeFactoryRegistry.getNodeIds(SparkNodeFactoryRegistry.java:114)
	at org.knime.bigdata.spark.core.node.SparkNodeSetFactory.getNodeFactoryIds(SparkNodeSetFactory.java:47)
	at org.knime.core.node.extension.NodeSetFactoryExtension.from(NodeSetFactoryExtension.java:296)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.Nodes$CollectorTask.doLeaf(Nodes.java:2183)
	at java.base/java.util.stream.Nodes$CollectorTask.doLeaf(Nodes.java:2149)
	at java.base/java.util.stream.AbstractTask.compute(AbstractTask.java:327)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: java.lang.ExceptionInInitializerError
	at org.knime.knip.base.data.img.ImgPlusCellFactory.getDataType(ImgPlusCellFactory.java:116)
	at org.knime.core.data.DataTypeRegistry.availableDataTypes(DataTypeRegistry.java:227)
	at org.knime.core.data.convert.java.DataCellToJavaConverterRegistry.parseAnnotations(DataCellToJavaConverterRegistry.java:481)
	at org.knime.core.data.convert.java.DataCellToJavaConverterRegistry.<init>(DataCellToJavaConverterRegistry.java:436)
	at org.knime.core.data.convert.java.DataCellToJavaConverterRegistry.<clinit>(DataCellToJavaConverterRegistry.java:427)
	at org.knime.base.node.jsnippet.JavaSnippet.cacheCustomTypeClasspaths(JavaSnippet.java:1262)
	at org.knime.base.node.jsnippet.JavaSnippetActivator.start(JavaSnippetActivator.java:68)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$2.run(BundleContextImpl.java:818)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$2.run(BundleContextImpl.java:1)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:810)
	... 43 more
Caused by: java.lang.IllegalArgumentException: Invalid service: org.scijava.event.DefaultEventService
	at org.scijava.service.ServiceHelper.createExactService(ServiceHelper.java:281)
	at org.scijava.service.ServiceHelper.loadService(ServiceHelper.java:232)
	at org.scijava.service.ServiceHelper.loadService(ServiceHelper.java:195)
	at org.scijava.service.ServiceHelper.loadServices(ServiceHelper.java:167)
	at org.scijava.Context.<init>(Context.java:281)
	at org.scijava.Context.<init>(Context.java:237)
	at org.scijava.Context.<init>(Context.java:213)
	at org.knime.knip.core.KNIPGateway.<init>(KNIPGateway.java:145)
	at org.knime.knip.core.KNIPGateway.getInstance(KNIPGateway.java:153)
	at org.knime.knip.core.KNIPGateway.cache(KNIPGateway.java:193)
	at org.knime.knip.base.data.img.ImgPlusCell.<clinit>(ImgPlusCell.java:120)
	... 54 more
Caused by: java.lang.IllegalArgumentException: No compatible service: org.scijava.log.LogService
	at org.scijava.service.ServiceHelper.loadService(ServiceHelper.java:244)
	at org.scijava.service.ServiceHelper.createServiceRecursively(ServiceHelper.java:341)
	at org.scijava.service.ServiceHelper.createExactService(ServiceHelper.java:270)
	... 64 more
```

AP-21672 (Broken Community Extension might break PortType#availablePortTypes (should try-catch ExceptionInInitializationError))